### PR TITLE
make job link stylable by css by giving it a class

### DIFF
--- a/juntagrico/templates/home.html
+++ b/juntagrico/templates/home.html
@@ -12,7 +12,7 @@
     </div>
     <div class="row mb-5">
         <div class="col-md-12">
-            <a href="/my/assignments">
+            <a href="/my/assignments" class="joblink">
                 {% trans "Hier alle Arbeitseinsätze anzeigen" %}
             </a>
         </div>


### PR DESCRIPTION
This will allow us and others to highlight this specific link, as it has been overlooked by users in the past.
Otherwise we have to override the entire template just for that. 