### PR TITLE
Fix bad characters in password in welcome mail

### DIFF
--- a/juntagrico/templates/mails/welcome_mail.txt
+++ b/juntagrico/templates/mails/welcome_mail.txt
@@ -11,7 +11,7 @@
 
 {% blocktrans %}Um dich auf {{serverurl}} einloggen zu können benutzte folgende Daten{% endblocktrans %}:
 {% trans "Email" %}: {{ username }}
-{% trans "Passwort" %}: {{ password }}" %}
+{% trans "Passwort" %}: {{ password }}
 {% trans "Bitte setze dir hier gleich ein neues Passwort:" %}
 {{serverurl}}/my/password
 


### PR DESCRIPTION
New members were receiving the welcome mail with special twig characters falsely appended to the password string hindering them from logging in.