### PR TITLE
remove space after dash

### DIFF
--- a/juntagrico/templates/createsubscription/select_subscription.html
+++ b/juntagrico/templates/createsubscription/select_subscription.html
@@ -36,9 +36,8 @@
                 </div>
                 <label class="col-md-9">
                     {% blocktrans trimmed %}
-                    Du kannst auch ohne {{ v_subscription }} {{ c_organisation_name }}-
-                    {{ v_member_type }} sein. Bleibe
-                    auf dem Laufenden und mach mit, wenn du Lust hast.
+                    Du kannst auch ohne {{ v_subscription }} {{ c_organisation_name }}-{{ v_member_type }}
+                    sein. Bleibe auf dem Laufenden und mach mit, wenn du Lust hast.
                     {% endblocktrans %}
                     <br/>
                     {% config "base_fee" as base_fee %}


### PR DESCRIPTION
There was a space after the dash, i.e.
Juntagrico-Mitglied vs. Juntagrico- Mitglied
(I hope I don't annoy you with PR like these :-) )