### PR TITLE
Fix convertion to timezone aware date

### DIFF
--- a/juntagrico/dao/assignmentdao.py
+++ b/juntagrico/dao/assignmentdao.py
@@ -23,8 +23,9 @@ class AssignmentDao:
 
     @staticmethod
     def assignments_for_member_current_business_year(member):
-        start = datetime.combine(start_of_business_year(), time.min, tzinfo=gdtz())
-        return juntagrico.entity.jobs.Assignment.objects.filter(member=member).filter(job__time__gte=start, job__time__lt=timezone.now())
+        start = gdtz().localize(datetime.combine(start_of_business_year(), time.min))
+        return juntagrico.entity.jobs.Assignment.objects.filter(member=member).\
+            filter(job__time__gte=start, job__time__lt=timezone.now())
 
     @staticmethod
     def upcomming_assignments_for_member(member):

--- a/juntagrico/dao/jobdao.py
+++ b/juntagrico/dao/jobdao.py
@@ -42,7 +42,7 @@ class JobDao:
 
     @staticmethod
     def get_jobs_for_current_day():
-        daystart = datetime.combine(date.today(), time.min, tzinfo=gdtz())
+        daystart = gdtz().localize(datetime.combine(date.today(), time.min))
         return Job.objects.filter(time__gte=daystart).order_by('time')
 
     @staticmethod

--- a/juntagrico/dao/memberdao.py
+++ b/juntagrico/dao/memberdao.py
@@ -78,7 +78,7 @@ class MemberDao:
     @staticmethod
     def annotate_members_with_assignemnt_count(members):
         now = timezone.now()
-        start = datetime.combine(start_of_business_year(), time.min, tzinfo=gdtz())
+        start = gdtz().localize(datetime.combine(start_of_business_year(), time.min))
         return members.annotate(assignment_count=Sum(
             Case(When(assignment__job__time__gte=start, assignment__job__time__lt=now, then='assignment__amount')))).annotate(
             core_assignment_count=Sum(Case(


### PR DESCRIPTION
Some convertions did not yield the expected results.  Assignments, that where close to the beginning of the business year were not counted.

`localize()` is the function, that "adds" the timezone information to a naive time (https://stackoverflow.com/a/13346065).
Found [here in Troubleshooting 3](https://docs.djangoproject.com/en/3.0/topics/i18n/timezones/#time-zones-faq).
