### PR TITLE
#209 recursion for the win

### DIFF
--- a/juntagrico/entity/subs.py
+++ b/juntagrico/entity/subs.py
@@ -49,6 +49,7 @@ class Subscription(Billable, SimpleStateModel):
 
     @staticmethod
     def get_part_overview(parts):
+        # building multi-dimensional dictionary [product_name][size_long_name][(type_name, type_long_name)] -> amount
         result = {}
         for part in parts.all():
             product_name = part.type.size.product.name

--- a/juntagrico/entity/subs.py
+++ b/juntagrico/entity/subs.py
@@ -61,7 +61,6 @@ class Subscription(Billable, SimpleStateModel):
             result[product_name] = product
         return result
 
-
     @property
     def part_overview(self):
         return Subscription.get_part_overview(self.active_parts)

--- a/juntagrico/entity/subs.py
+++ b/juntagrico/entity/subs.py
@@ -48,22 +48,27 @@ class Subscription(Billable, SimpleStateModel):
         return '%s' % (' + '.join(namelist))
 
     @staticmethod
-    def get_size_name(parts):
-        size_dict = {}
+    def get_part_overview(parts):
+        result = {}
         for part in parts.all():
-            size_dict[str(part.type)] = 1 + size_dict.get(str(part.type), 0)
-        size_names = [key + ':' + str(value) for key, value in size_dict.items()]
-        if len(size_names) > 0:
-            return '<br>'.join(size_names)
-        return _('keine {0}-Bestandteile').format(Config.vocabulary('subscription'))
+            product_name = part.type.size.product.name
+            product = result.get(product_name, {})
+            size_name = part.type.size.long_name
+            size = product.get(size_name, {})
+            type_name = (part.type.name, part.type.long_name)
+            size[type_name] = 1 + size.get(type_name, 0)
+            product[size_name] = size
+            result[product_name] = product
+        return result
+
 
     @property
-    def size_name(self):
-        return Subscription.get_size_name(self.active_parts)
+    def part_overview(self):
+        return Subscription.get_part_overview(self.active_parts)
 
     @property
-    def future_size_name(self):
-        return Subscription.get_size_name(self.future_parts)
+    def future_part_overview(self):
+        return Subscription.get_part_overview(self.future_parts)
 
     @property
     def active_parts(self):

--- a/juntagrico/templates/management_lists/typechangelist.html
+++ b/juntagrico/templates/management_lists/typechangelist.html
@@ -1,6 +1,7 @@
 {% extends "management_lists/man_list_base.html" %}
 {% load i18n %}
 {% load config %}
+{% load subscription %}
 {% block page_title %}
     <h3>
         {% trans "Bestandteile Änderungsliste" %}
@@ -54,10 +55,10 @@
                         </form>
                     </td>
                     <td>
-                        {{ subscription.size_name }}
+                        {{ subscription.part_overview|overview|safe }}
                     </td>
                     <td>
-                        {{ subscription.future_size_name }}
+                        {{ subscription.future_part_overview|overview|safe }}
                     </td>
                     <td>
                         {{ subscription.part_change_date|date:"Y-m-d" }}

--- a/juntagrico/templates/snippets/snippet_subscription_change_size.html
+++ b/juntagrico/templates/snippets/snippet_subscription_change_size.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load config %}
+{% load subscription %}
 {% vocabulary "subscription" as v_subscription %}
 <div class="row mt-3">
     <div class="col-md-2">

--- a/juntagrico/templates/snippets/snippet_subscription_change_size.html
+++ b/juntagrico/templates/snippets/snippet_subscription_change_size.html
@@ -20,7 +20,7 @@
         <br/>
         {% trans "Zukünftige Bestandteile" %}:
         <br/>
-        {{ subscription.future_size_name|safe }}
+        {{ subscription.future_size_name|overview|safe }}
         <br/>
     </div>
     <div class="col-md-2">

--- a/juntagrico/templates/snippets/snippet_subscription_change_size.html
+++ b/juntagrico/templates/snippets/snippet_subscription_change_size.html
@@ -21,7 +21,7 @@
         <br/>
         {% trans "Zukünftige Bestandteile" %}:
         <br/>
-        {{ subscription.future_size_name|overview|safe }}
+        {{ subscription.future_part_overview|overview|safe }}
         <br/>
     </div>
     <div class="col-md-2">

--- a/juntagrico/templates/subscription.html
+++ b/juntagrico/templates/subscription.html
@@ -218,7 +218,7 @@
                     Die Änderung tritt voraussichtlich am {{ nes }} in Kraft
                     {% endblocktrans %})
                     <br/>
-                    {{ subscription.future_size_name|safe }}
+                    {{ subscription.future_part_overview|overview|safe }}
                 </div>
             </div>
         {% endif %}

--- a/juntagrico/templates/subscription.html
+++ b/juntagrico/templates/subscription.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load config %}
+{% load subscription %}
 {% block page_title %}
     {% vocabulary "subscription" as v_subscription %}
     <h3>
@@ -56,7 +57,7 @@
                 {% blocktrans %}{{ v_subscription }}-Bestandteile{% endblocktrans %}
             </div>
             <div class="col-md-9">
-                {{ subscription.size_name|safe }}
+                {{ subscription.part_overview|overview|safe }}
             </div>
         </div>
         <div class="row mb-3">

--- a/juntagrico/templates/subscription.html
+++ b/juntagrico/templates/subscription.html
@@ -57,7 +57,11 @@
                 {% blocktrans %}{{ v_subscription }}-Bestandteile{% endblocktrans %}
             </div>
             <div class="col-md-9">
+                {% if subscription.state == 'waiting' %}
+                {{ subscription.future_part_overview|overview|safe }}
+                {% else %}
                 {{ subscription.part_overview|overview|safe }}
+                {% endif %}
             </div>
         </div>
         <div class="row mb-3">

--- a/juntagrico/templatetags/subscription.py
+++ b/juntagrico/templatetags/subscription.py
@@ -1,0 +1,27 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def overview(part_overview):
+    def loop(result_list, key, value, more_than_one=False):
+        if more_than_one:
+            result_list.append('<li>{}</li>'.format(key))
+            result_list.append('<ul>')
+        for new_key, new_value in value.items():
+            if isinstance(new_value, int):
+                display_name = new_key[1] if new_key[1] != '' else key
+                result_list.append('<li> {} : {} </li>'.format(display_name, new_value))
+            else:
+                loop(result_list, new_key, new_value, len(value.items()) > 1)
+        if more_than_one:
+            result_list.append('</ul>')
+
+    result = ['<ul>']
+    loop(result, '', part_overview)
+    result.append('</ul>')
+    return '\n'.join(result)
+
+
+

--- a/juntagrico/templatetags/subscription.py
+++ b/juntagrico/templatetags/subscription.py
@@ -12,7 +12,7 @@ def overview(part_overview):
         for new_key, new_value in value.items():
             if isinstance(new_value, int):
                 display_name = new_key[1] if new_key[1] != '' else key
-                result_list.append('<li> {} : {} </li>'.format(display_name, new_value))
+                result_list.append('<li> {} x {} </li>'.format(new_value, display_name))
             else:
                 loop(result_list, new_key, new_value, len(value.items()) > 1)
         if more_than_one:

--- a/juntagrico/templatetags/subscription.py
+++ b/juntagrico/templatetags/subscription.py
@@ -22,6 +22,3 @@ def overview(part_overview):
     loop(result, '', part_overview)
     result.append('</ul>')
     return '\n'.join(result)
-
-
-

--- a/juntagrico/templatetags/subscription.py
+++ b/juntagrico/templatetags/subscription.py
@@ -12,7 +12,7 @@ def overview(part_overview):
         for new_key, new_value in value.items():
             if isinstance(new_value, int):
                 display_name = new_key[1] if new_key[1] != '' else key
-                result_list.append('<li> {} x {} </li>'.format(new_value, display_name))
+                result_list.append('<li> {}× {} </li>'.format(new_value, display_name))
             else:
                 loop(result_list, new_key, new_value, len(value.items()) > 1)
         if more_than_one:


### PR DESCRIPTION
this solution will collapse (or not diplay) all levels which have only one sibling
since it is clear that it is milk for basimilch or  vegetables for meh als gmües since it is the only one
but may be if there is more than one product this does not make sense any more, maybe this is somethin i have to adapt but then the recursion has to be adapted 
maybe all the collapsing should not be done this would make the code far more easier and would allways be right
also it takes the types long name otherwise the size name since for example with ortoloco the type name is not meaningfull to the member
