### PR TITLE
Clarify mail address not confirmed text in sub view

### DIFF
--- a/juntagrico/templates/subscription.html
+++ b/juntagrico/templates/subscription.html
@@ -110,7 +110,7 @@
                                 {{ ln }}
                                 {% endblocktrans %}
                                 {% if not co_member.confirmed %}
-                                    ({% trans "nicht bestätigt" %})
+                                    ({% trans "E-Mail-Adresse nicht bestätigt" %})
                                 {% endif %}
                             </li>
                         {% endfor %}


### PR DESCRIPTION
There was confusion for some members what that means, needed clarification