### PR TITLE
include admin and user menus in loop.

### DIFF
--- a/juntagrico/templates/menu/admin_menu.html
+++ b/juntagrico/templates/menu/admin_menu.html
@@ -210,5 +210,7 @@
             </a>
         </li>
     {% endif %}
-    {% include admin_menus %}
+    {% for menu in admin_menus %}
+        {% include menu %}
+    {% endfor %}
 </ul>

--- a/juntagrico/templates/menu/user_menu.html
+++ b/juntagrico/templates/menu/user_menu.html
@@ -53,7 +53,9 @@
             {% trans "Kontakt" %}
         </a>
     </li>
-    {% include user_menus %}
+    {% for menu in user_menus %}
+        {% include menu %}
+    {% endfor %}
     <li class="separator">
     </li>
     <li class="nav-item main-menu-small">


### PR DESCRIPTION
changed inclusion of custom and addon menus back to using a loop.
the include tag doesn't really support lists, it just uses the first item in an iterable.
should close #274.