### PR TITLE
Fix default order on create subscription page

### DIFF
--- a/juntagrico/entity/subtypes.py
+++ b/juntagrico/entity/subtypes.py
@@ -23,7 +23,7 @@ class SubscriptionProduct(JuntagricoBaseModel):
     class Meta:
         verbose_name = _('{0}-Produkt').format(Config.vocabulary('subscription'))
         verbose_name_plural = _('{0}-Produkt').format(Config.vocabulary('subscription'))
-
+        ordering = ['pk']
 
 class SubscriptionSize(JuntagricoBaseModel):
     '''
@@ -48,7 +48,7 @@ class SubscriptionSize(JuntagricoBaseModel):
         verbose_name_plural = _('{0}-Grössen').format(Config.vocabulary('subscription'))
         unique_together = ('name', 'product',)
         unique_together = ('units', 'product',)
-
+        ordering = ['pk']
 
 class SubscriptionType(JuntagricoBaseModel):
     '''
@@ -81,3 +81,4 @@ class SubscriptionType(JuntagricoBaseModel):
     class Meta:
         verbose_name = _('{0}-Typ').format(Config.vocabulary('subscription'))
         verbose_name_plural = _('{0}-Typen').format(Config.vocabulary('subscription'))
+        ordering = ['pk']

--- a/juntagrico/entity/subtypes.py
+++ b/juntagrico/entity/subtypes.py
@@ -23,7 +23,7 @@ class SubscriptionProduct(JuntagricoBaseModel):
     class Meta:
         verbose_name = _('{0}-Produkt').format(Config.vocabulary('subscription'))
         verbose_name_plural = _('{0}-Produkt').format(Config.vocabulary('subscription'))
-        ordering = ['pk']
+
 
 class SubscriptionSize(JuntagricoBaseModel):
     '''
@@ -48,7 +48,7 @@ class SubscriptionSize(JuntagricoBaseModel):
         verbose_name_plural = _('{0}-Grössen').format(Config.vocabulary('subscription'))
         unique_together = ('name', 'product',)
         unique_together = ('units', 'product',)
-        ordering = ['pk']
+
 
 class SubscriptionType(JuntagricoBaseModel):
     '''
@@ -81,4 +81,3 @@ class SubscriptionType(JuntagricoBaseModel):
     class Meta:
         verbose_name = _('{0}-Typ').format(Config.vocabulary('subscription'))
         verbose_name_plural = _('{0}-Typen').format(Config.vocabulary('subscription'))
-        ordering = ['pk']

--- a/juntagrico/forms.py
+++ b/juntagrico/forms.py
@@ -297,11 +297,11 @@ class SubscriptionPartBaseForm(Form):
 
     def _collect_type_fields(self):
         containers = []
-        for product in SubscriptionProductDao.get_all_visible():
+        for product in SubscriptionProductDao.get_all_visible().order_by('pk'):
             product_container = CategoryContainer(instance=product)
-            for subscription_size in product.sizes.filter(visible=True):
+            for subscription_size in product.sizes.filter(visible=True).order_by('pk'):
                 size_container = CategoryContainer(instance=subscription_size, name=subscription_size.long_name)
-                for subscription_type in subscription_size.types.filter(visible=True):
+                for subscription_type in subscription_size.types.filter(visible=True).order_by('pk'):
                     field_name = f'amount[{subscription_type.id}]'
                     self.fields[field_name] = IntegerField(label=subscription_type.name, min_value=0,
                                                            initial=self._get_initial(subscription_type))


### PR DESCRIPTION
Currently, the products do not have a default order on the create subscription page and thus their order can change and is unpredictable. Let's introduce this quick fix / workaround to at least fix the order to the order of creation (reflected by primary key).