### PR TITLE
Make share creation text more specific regarding NEW shares

### DIFF
--- a/juntagrico/templates/createsubscription/select_shares.html
+++ b/juntagrico/templates/createsubscription/select_shares.html
@@ -62,7 +62,7 @@
             {% csrf_token %}
             <div class="form-group row">
                 <label class="col-md-3 col-form-label">
-                    {% blocktrans %}Deine {{ v_share_pl }}{% endblocktrans %}
+                    {% blocktrans %}Neue {{ v_share_pl }}{% endblocktrans %}:
                 </label>
                 <div class="col-md-3">
                     <input type="number" name="shares_mainmember" class="form-control" value="{{ member.new_shares|default:shares.total_required }}" min="{% if shares.existing_main_member == 0 %}1{% else %}0{% endif %}"/>


### PR DESCRIPTION
Replace "Deine Anteilscheine" with "Neue Anteilscheine" to make clear that the input field contains the number of NEW shares for the member.