### PR TITLE
Fixed overlapping header in depot overview pdf.

### DIFF
--- a/juntagrico/templates/exports/depot_overview.html
+++ b/juntagrico/templates/exports/depot_overview.html
@@ -12,7 +12,7 @@
 
 <body>
 {% for weekday_name, weekday_id in weekdays.items %}
-<div id="header_content">
+<div id="header_content" style="text-align:right">
     {% trans "Erstellt am" %} {% now "d.m.Y H:i" %}
 </div>
     <h2 style="font-size: 18px;">{{ weekday_name }}</h2>


### PR DESCRIPTION
Before:

![Screenshot 2021-04-27 10:12:40](https://user-images.githubusercontent.com/230094/116208474-422eac80-a741-11eb-8942-fb38afe96624.png)

Moved the created on timestamp to the upper-right.

After:

![Screenshot 2021-04-27 10:15:32](https://user-images.githubusercontent.com/230094/116208873-9fc2f900-a741-11eb-8d2f-029d871d1095.png)
