### PR TITLE
Fix assignment edit

### DIFF
--- a/docs/1_4_release_notes.rst
+++ b/docs/1_4_release_notes.rst
@@ -4,6 +4,14 @@ Release Notes
 Dev
 ---
 
+Fixes
+^^^^^
+* Fix: Allow editing of assignments via admin
+* Fix link in admin main page from "show" to "edit" where it was wrong
+
+1.4.2
+-----
+
 Features & Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^
 * Member Features:
@@ -25,9 +33,9 @@ Fixes
 * Only show depot access information for current depot
 * Use informal language consistently in password reset process
 * Menu fixes:
-  * Make assignment admin menu entry visible as documented
-  * Highlight jobs menu entry when page is active
-  * Fix view access to match menu visibility
+    * Make assignment admin menu entry visible as documented
+    * Highlight jobs menu entry when page is active
+    * Fix view access to match menu visibility
 * Fix membership cancellation
 * Upgraded datatables.js to fix issue with search builder on Safari
 

--- a/juntagrico/admins/assignment_admin.py
+++ b/juntagrico/admins/assignment_admin.py
@@ -9,10 +9,10 @@ class AssignmentAdmin(BaseAdmin):
     raw_id_fields = ['member', 'job']
 
     def has_change_permission(self, request, obj=None):
-        return obj is not None and obj.can_modify(request) and super().has_change_permission(request, obj)
+        return (obj is None or obj.can_modify(request)) and super().has_change_permission(request, obj)
 
     def has_delete_permission(self, request, obj=None):
-        return obj is not None and obj.can_modify(request) and super().has_delete_permission(request, obj)
+        return (obj is None or obj.can_modify(request)) and super().has_delete_permission(request, obj)
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -23,10 +23,10 @@ class JobAdmin(RichTextAdmin):
     readonly_fields = ['free_slots']
 
     def has_change_permission(self, request, obj=None):
-        return obj is not None and obj.can_modify(request) and super().has_change_permission(request, obj)
+        return (obj is None or obj.can_modify(request)) and super().has_change_permission(request, obj)
 
     def has_delete_permission(self, request, obj=None):
-        return obj is not None and obj.can_modify(request) and super().has_delete_permission(request, obj)
+        return (obj is None or obj.can_modify(request)) and super().has_delete_permission(request, obj)
 
     @admin.action(description=_('Job mehrfach kopieren...'))
     @single_element_action('Genau 1 Job auswählen!')

--- a/juntagrico/admins/subscription_admin.py
+++ b/juntagrico/admins/subscription_admin.py
@@ -45,9 +45,7 @@ class SubscriptionAdmin(BaseAdmin):
 
     @staticmethod
     def can_change_deactivated_subscription(request, obj=None):
-        if obj is None:
-            return False
-        return not obj.inactive or (
+        return obj is None or not obj.inactive or (
             request.user.is_superuser or request.user.has_perm('juntagrico.can_change_deactivated_subscriptions'))
 
     def has_change_permission(self, request, obj=None):

--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -323,7 +323,7 @@ class Assignment(JuntagricoBaseModel):
         instance.core_cache = instance.is_core()
 
     def can_modify(self, request):
-        self.job.can_modify(request)
+        return self.job.can_modify(request)
 
     class Meta:
         verbose_name = Config.vocabulary('assignment')


### PR DESCRIPTION
As Patricia described in slack: https://juntagrico.slack.com/archives/CGFPD8L2Y/p1635184079005900
- Assignments could not be edited since update
- On admin main page the "show" link is displayed instead of "edit". But the entries inside are actually editable.