### PR TITLE
fix share payment file export and test coverage

### DIFF
--- a/docs/1_4_release_notes.rst
+++ b/docs/1_4_release_notes.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+Dev
+---
+
+Fixes
+^^^^^
+* Fix export of share payment file (pain.001)
+
 1.4.3
 -----
 

--- a/juntagrico/views_iso20022.py
+++ b/juntagrico/views_iso20022.py
@@ -21,7 +21,7 @@ def share_pain001(request):
     payable_shares = [share for share in shares if share.member.iban is not None and share.member.iban != '']
     total_amount = 0
     for share in payable_shares:
-        total_amount = total_amount + share['value']
+        total_amount = total_amount + share.value
     context = {
         'shares': payable_shares,
         'nmbr_of_tx': len(payable_shares),

--- a/test/test_iso20022.py
+++ b/test/test_iso20022.py
@@ -5,6 +5,12 @@ from test.util.test import JuntagricoTestCase
 
 class ISO2002Tests(JuntagricoTestCase):
 
+    def setUp(self):
+        super().setUp()
+        # add iban to member such that tested share can be paid back.
+        self.member.iban = 'CH6189144414396247884'
+        self.member.save()
+
     def testSharePAIN001(self):
         self.assertPost(reverse('share-pain001'), data={'share_ids': str(self.share.pk)})
 


### PR DESCRIPTION
Creating the payment file failed, when there was actually a payable share to export.