### PR TITLE
#90 fix: apply same past editing limitation to one time jobs

### DIFF
--- a/docs/1_4_release_notes.rst
+++ b/docs/1_4_release_notes.rst
@@ -12,6 +12,7 @@ Features & Improvements
 Fixes
 ^^^^^
 * Fix export of share payment file (pain.001)
+* Fix past job editing limitation for one time jobs
 
 1.4.3
 -----

--- a/juntagrico/admins/one_time_job_admin.py
+++ b/juntagrico/admins/one_time_job_admin.py
@@ -22,6 +22,12 @@ class OneTimeJobAdmin(RichTextAdmin):
     inlines = [AssignmentInline, JobExtraInline]
     readonly_fields = ['free_slots']
 
+    def has_change_permission(self, request, obj=None):
+        return (obj is None or obj.can_modify(request)) and super().has_change_permission(request, obj)
+
+    def has_delete_permission(self, request, obj=None):
+        return (obj is None or obj.can_modify(request)) and super().has_delete_permission(request, obj)
+
     @admin.action(description=_('EinzelJobs in Jobart konvertieren'))
     def transform_job(self, request, queryset):
         for inst in queryset.all():


### PR DESCRIPTION
Somebody in our cooperative figured out that one time jobs were not protected (anymore) :-)