### PR TITLE
Check Share Cancellation

### DIFF
--- a/docs/1_4_release_notes.rst
+++ b/docs/1_4_release_notes.rst
@@ -7,6 +7,7 @@ Dev
 Fixes
 ^^^^^
 * Fix export of share payment file (pain.001)
+* Fix unauthorized share cancellation
 
 1.4.3
 -----

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -117,6 +117,21 @@ class Member(JuntagricoBaseModel):
         return self.usable_shares.count()
 
     @property
+    def required_shares_count(self):
+        # calculate required shares backwards to account for shared subscriptions
+        not_canceled_share_count = self.usable_shares_count
+        overflow_list = [not_canceled_share_count]
+        if self.subscription_future is not None:
+            overflow_list.append(self.subscription_future.share_overflow)
+        if self.subscription_current is not None:
+            overflow_list.append(self.subscription_current.share_overflow)
+        return not_canceled_share_count - min(overflow_list)
+
+    @property
+    def cancellable_shares_count(self):
+        return self.usable_shares_count - max(self.required_shares_count, 1)
+
+    @property
     def subscription_future(self):
         sub_membership = self.subscriptionmembership_set.filter(~q_joined_subscription()).first()
         return getattr(sub_membership, 'subscription', None)


### PR DESCRIPTION
One of our members managed to cancel all shares without cancelling the subscription or membership. Only the cancellation date was set, not the deactivation date.
I could not find a loop hole besides this one, where the member might have actively opened the URL with the modified id to cancel the "uncancallable".