### PR TITLE
feat: add member to default activity area on sub join

### DIFF
--- a/juntagrico/admins/area_admin.py
+++ b/juntagrico/admins/area_admin.py
@@ -7,7 +7,7 @@ from juntagrico.util.admin import queryset_for_coordinator
 class AreaAdmin(SortableAdminMixin, RichTextAdmin):
     filter_horizontal = ['members']
     raw_id_fields = ['coordinator']
-    list_display = ['name', 'core', 'hidden', 'coordinator', 'get_email']
+    list_display = ['name', 'core', 'hidden', 'coordinator', 'get_email', 'auto_add_new_members']
 
     def get_queryset(self, request):
         return queryset_for_coordinator(self, request, 'coordinator')

--- a/juntagrico/dao/activityareadao.py
+++ b/juntagrico/dao/activityareadao.py
@@ -16,5 +16,9 @@ class ActivityAreaDao:
         return ActivityArea.objects.filter(hidden=False).order_by('-core', 'name')
 
     @staticmethod
+    def all_auto_add_members_areas():
+        return ActivityArea.objects.filter(auto_add_new_members=True)
+
+    @staticmethod
     def all_core_areas():
         return ActivityArea.objects.filter(core=True)

--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -30,7 +30,7 @@ class ActivityArea(JuntagricoBaseModel):
     sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)
     auto_add_new_members = models.BooleanField(_('Standard Tätigkeitesbereich für neue Benutzer'), default=False,
                                                help_text=_(
-                                                   'Neue Benutzer automatisch zu diesem Tätigkeitsbereich hinzufügen.'))
+                                                   'Neue Benutzer werden automatisch zu diesem Tätigkeitsbereich hinzugefügt.'))
 
     def __str__(self):
         return '%s' % self.name

--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -28,6 +28,9 @@ class ActivityArea(JuntagricoBaseModel):
     members = models.ManyToManyField(
         'Member', related_name='areas', blank=True, verbose_name=Config.vocabulary('member_pl'))
     sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)
+    auto_add_new_members = models.BooleanField(_('Standard Tätigkeitesbereich für neue Benutzer'), default=False,
+                                               help_text=_(
+                                                   'Neue Benutzer automatisch zu diesem Tätigkeitsbereich hinzufügen.'))
 
     def __str__(self):
         return '%s' % self.name

--- a/juntagrico/entity/subtypes.py
+++ b/juntagrico/entity/subtypes.py
@@ -75,6 +75,8 @@ class SubscriptionType(JuntagricoBaseModel):
     description = models.TextField(
         _('Beschreibung'), max_length=1000, blank=True)
     sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)
+    default_activity_area = models.ForeignKey(
+        'ActivityArea', on_delete=models.PROTECT, null=True, blank=True, verbose_name=_('Standard Tätigkeitsbereich'))
 
     @property
     def has_periods(self):

--- a/juntagrico/entity/subtypes.py
+++ b/juntagrico/entity/subtypes.py
@@ -75,8 +75,6 @@ class SubscriptionType(JuntagricoBaseModel):
     description = models.TextField(
         _('Beschreibung'), max_length=1000, blank=True)
     sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)
-    default_activity_area = models.ForeignKey(
-        'ActivityArea', on_delete=models.PROTECT, null=True, blank=True, verbose_name=_('Standard Tätigkeitsbereich'))
 
     @property
     def has_periods(self):

--- a/juntagrico/management/commands/generate_testdata.py
+++ b/juntagrico/management/commands/generate_testdata.py
@@ -70,9 +70,11 @@ class Command(BaseCommand):
         SubscriptionPart.objects.create(subscription=subscription_2, type=subtype, activation_date=datetime.datetime.strptime('27/03/17', '%d/%m/%y').date())
 
         area1_fields = {'name': 'Ernten', 'description': 'Das Gemüse aus der Erde Ziehen', 'core': True,
-                        'hidden': False, 'coordinator': member_1, 'show_coordinator_phonenumber': False}
+                        'hidden': False, 'coordinator': member_1, 'show_coordinator_phonenumber': False,
+                        'auto_add_new_members': True}
         area2_fields = {'name': 'Jäten', 'description': 'Das Unkraut aus der Erde Ziehen', 'core': False,
-                        'hidden': False, 'coordinator': member_2, 'show_coordinator_phonenumber': False}
+                        'hidden': False, 'coordinator': member_2, 'show_coordinator_phonenumber': False,
+                        'auto_add_new_members': False}
         area_1 = ActivityArea.objects.create(**area1_fields)
         area_1.members.set([member_2])
         area_1.save()

--- a/juntagrico/management/commands/generate_testdata_advanced.py
+++ b/juntagrico/management/commands/generate_testdata_advanced.py
@@ -165,9 +165,11 @@ class Command(BaseCommand):
                 self.generate_depot_sub(depot, options['sub_shares'], type)
 
         area1_fields = {'name': 'Ernten', 'description': 'Das Gemüse aus der Erde Ziehen', 'core': True,
-                        'hidden': False, 'coordinator': self.members[0], 'show_coordinator_phonenumber': False}
+                        'hidden': False, 'coordinator': self.members[0], 'show_coordinator_phonenumber': False,
+                        'auto_add_new_members': True}
         area2_fields = {'name': 'Jäten', 'description': 'Das Unkraut aus der Erde Ziehen', 'core': False,
-                        'hidden': False, 'coordinator': self.members[1], 'show_coordinator_phonenumber': False}
+                        'hidden': False, 'coordinator': self.members[1], 'show_coordinator_phonenumber': False,
+                        'auto_add_new_members': False}
         area_1, _ = ActivityArea.objects.get_or_create(
             name=area1_fields['name'],
             defaults=area1_fields

--- a/juntagrico/templates/createsubscription/summary.html
+++ b/juntagrico/templates/createsubscription/summary.html
@@ -98,7 +98,7 @@
                 {% endfor %}
             </ul>
 
-            <p>{% blocktrans %}Du kannst das später in den Einstellungen ändern.{% endblocktrans %}</p>
+            <p>{% blocktrans %}Du kannst das jederzeit unter dem Menupunkt Tätigkeitsbereiche ändern.{% endblocktrans %}</p>
         {% endif %}
 
         {% if c_enable_shares %}

--- a/juntagrico/templates/createsubscription/summary.html
+++ b/juntagrico/templates/createsubscription/summary.html
@@ -89,6 +89,18 @@
             </a></p>
         {% endif %}
 
+        {% if activity_areas %}
+            <h4>{% trans "Tätigkeitsbereiche" %}</h4>
+            <p>{% blocktrans %}Du wird automatisch in folgende Tätigkeitsbereiche eingetragen.{% endblocktrans %}</p>
+            <ul>
+                {% for area in activity_areas %}
+                    <li><strong>{{ area.name }}</strong> {{ area.description |safe }}</li>
+                {% endfor %}
+            </ul>
+
+            <p>{% blocktrans %}Du kannst das später in den Einstellungen ändern.{% endblocktrans %}</p>
+        {% endif %}
+
         {% if c_enable_shares %}
             <h4>{% trans "Anteilscheine" %} <a href="{% url 'cs-shares' %}" class="edit"><i class="fas fa-pen"></i></a></h4>
             <p>

--- a/juntagrico/views_create_subscription.py
+++ b/juntagrico/views_create_subscription.py
@@ -5,6 +5,7 @@ from django.views.generic.edit import ModelFormMixin
 
 from juntagrico.config import Config
 from juntagrico.dao.depotdao import DepotDao
+from juntagrico.entity.jobs import ActivityArea
 from juntagrico.forms import SubscriptionForm, EditCoMemberForm, RegisterMultiCoMemberForm, \
     RegisterFirstMultiCoMemberForm, SubscriptionPartSelectForm, RegisterSummaryForm
 from juntagrico.util import temporal
@@ -202,9 +203,11 @@ class CSSummaryView(FormView):
         return {'comment': getattr(self.cs_session.main_member, 'comment', '')}
 
     def get_context_data(self, **kwargs):
+        args = self.cs_session.to_dict()
+        args['activity_areas'] = ActivityArea.objects.filter(auto_add_new_members=True)
         return super().get_context_data(
             **{},
-            **self.cs_session.to_dict(),
+            **args,
             **kwargs
         )
 

--- a/juntagrico/views_create_subscription.py
+++ b/juntagrico/views_create_subscription.py
@@ -4,8 +4,8 @@ from django.views.generic import TemplateView, FormView
 from django.views.generic.edit import ModelFormMixin
 
 from juntagrico.config import Config
+from juntagrico.dao.activityareadao import ActivityAreaDao
 from juntagrico.dao.depotdao import DepotDao
-from juntagrico.entity.jobs import ActivityArea
 from juntagrico.forms import SubscriptionForm, EditCoMemberForm, RegisterMultiCoMemberForm, \
     RegisterFirstMultiCoMemberForm, SubscriptionPartSelectForm, RegisterSummaryForm
 from juntagrico.util import temporal
@@ -204,7 +204,7 @@ class CSSummaryView(FormView):
 
     def get_context_data(self, **kwargs):
         args = self.cs_session.to_dict()
-        args['activity_areas'] = ActivityArea.objects.filter(auto_add_new_members=True)
+        args['activity_areas'] = ActivityAreaDao.all_auto_add_members_areas()
         return super().get_context_data(
             **{},
             **args,

--- a/juntagrico/views_subscription.py
+++ b/juntagrico/views_subscription.py
@@ -14,12 +14,12 @@ from django.views.generic import FormView
 from django.views.generic.edit import ModelFormMixin
 
 from juntagrico.config import Config
+from juntagrico.dao.activityareadao import ActivityAreaDao
 from juntagrico.dao.depotdao import DepotDao
 from juntagrico.dao.memberdao import MemberDao
 from juntagrico.dao.subscriptionproductdao import SubscriptionProductDao
 from juntagrico.entity.depot import Depot
-from juntagrico.entity.jobs import ActivityArea
-from juntagrico.entity.member import Member, SubscriptionMembership
+from juntagrico.entity.member import Member
 from juntagrico.entity.share import Share
 from juntagrico.entity.subs import Subscription, SubscriptionPart
 from juntagrico.forms import RegisterMemberForm, EditMemberForm, AddCoMemberForm, SubscriptionPartOrderForm, \
@@ -314,14 +314,7 @@ def activate_subscription(request, subscription_id):
 
 
 def add_subscription_member_to_activity_area(subscription):
-    activity_area = ActivityArea.objects.filter(auto_add_new_members=True)
-    member_ids = SubscriptionMembership.objects.filter(subscription=subscription).values_list('member')
-    members = Member.objects.filter(pk__in=member_ids)
-
-    for member in members:
-        for area in activity_area:
-            if member not in area.members.all():
-                area.members.add(member)
+    [area.members.add(*subscription.recipients_all) for area in ActivityAreaDao.all_auto_add_members_areas()]
 
 
 @permission_required('juntagrico.is_operations_group')

--- a/juntagrico/views_subscription.py
+++ b/juntagrico/views_subscription.py
@@ -307,13 +307,13 @@ def activate_subscription(request, subscription_id):
     change_date = request.session.get('changedate', None)
     try:
         subscription.activate(change_date)
-        add_user_to_activity_area(subscription)
+        add_subscription_member_to_activity_area(subscription)
     except ValidationError as e:
         return error_page(request, e.message)
     return return_to_previous_location(request)
 
 
-def add_user_to_activity_area(subscription):
+def add_subscription_member_to_activity_area(subscription):
     activity_area = ActivityArea.objects.filter(auto_add_new_members=True)
     member_ids = SubscriptionMembership.objects.filter(subscription=subscription).values_list('member')
     members = Member.objects.filter(pk__in=member_ids)

--- a/test/test_subs.py
+++ b/test/test_subs.py
@@ -14,8 +14,10 @@ class SubscriptionTests(JuntagricoTestCase):
     def testSubActivation(self):
         self.assertGet(reverse('sub-activate', args=[self.sub2.pk]), 302)
         self.member2.refresh_from_db()
+        self.area.refresh_from_db()
         self.assertIsNone(self.member2.subscription_future)
         self.assertEqual(self.member2.subscription_current, self.sub2)
+        self.assertTrue(self.member2 in self.area.members.all())
 
     def testSubChange(self):
         self.assertGet(reverse('sub-change', args=[self.sub.pk]))

--- a/test/util/test.py
+++ b/test/util/test.py
@@ -146,7 +146,8 @@ class JuntagricoTestCase(TestCase):
         area
         """
         area_data = {'name': 'name',
-                     'coordinator': self.area_admin}
+                     'coordinator': self.area_admin,
+                     'auto_add_new_members': True}
         area_data2 = {'name': 'name2',
                       'coordinator': self.area_admin,
                       'hidden': True}


### PR DESCRIPTION
- Add a default activity area to subtypes
- adds member to the default activity area if added to the related sub
- contains migration on Subscri

TODO:
- [ ] regenerate translations files. What is the command for that?
- [x] add tests if feature request was understood correctly (see comment on issue #452 )