### PR TITLE
Fix sub order process and template issues and extend tests

### DIFF
--- a/docs/1_4_release_notes.rst
+++ b/docs/1_4_release_notes.rst
@@ -7,6 +7,7 @@ Dev
 Fixes
 ^^^^^
 * Fix export of share payment file (pain.001)
+* Fix minor template issues
 
 1.4.3
 -----

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -155,6 +155,11 @@ class Member(JuntagricoBaseModel):
         return (self.subscription_future is not None) | (self.subscription_current is not None)
 
     @property
+    def can_order_subscription(self):
+        return self.subscription_future is None and (
+            self.subscription_current is None or self.subscription_current.cancellation_date is not None)
+
+    @property
     def blocked(self):
         future = self.subscription_future is not None
         current = self.subscription_current is not None and not self.subscription_current.inactive

--- a/juntagrico/mailer/adminnotification.py
+++ b/juntagrico/mailer/adminnotification.py
@@ -84,6 +84,8 @@ def share_canceled(share, **kwargs):
 
 @requires_someone_with_perm('notified_on_member_creation')
 def member_created(member, **kwargs):
+    if not hasattr(member, 'comment'):
+        member.comment = ''
     EmailSender.get_sender(
         organisation_subject(_('Neue/r/s {}').format(Config.vocabulary('member_type'))),
         get_email_content('a_member_created', base_dict(locals())),

--- a/juntagrico/mailer/adminnotification.py
+++ b/juntagrico/mailer/adminnotification.py
@@ -29,7 +29,7 @@ def member_left_activityarea(area, member):
 
 
 @requires_someone_with_perm('notified_on_subscription_creation')
-def subscription_created(subscription, **kwargs):
+def subscription_created(subscription, comment='', **kwargs):
     EmailSender.get_sender(
         organisation_subject(_('Neue/r/s {} erstellt').format(Config.vocabulary('subscription'))),
         get_email_content('n_sub', base_dict(locals())),

--- a/juntagrico/management/commands/mailtexts.py
+++ b/juntagrico/management/commands/mailtexts.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
 
         print('*** n_sub ***')
 
-        print(get_email_content('n_sub', base_dict({'subscription': subscription})))
+        print(get_email_content('n_sub', base_dict({'subscription': subscription, 'comment': 'user comment'})))
         print()
 
         print('*** co_welcome ***')

--- a/juntagrico/templates/createsubscription/select_shares.html
+++ b/juntagrico/templates/createsubscription/select_shares.html
@@ -51,8 +51,8 @@
                     <br/>
                 {% endif %}
                 {% if co_members|length > 0 %}
-                    {% blocktrans trimmed %}
-                    Teile die restlichen benötigten {{ shares.remaining_required }} {{ v_share_pl }} unter dir und
+                    {% blocktrans trimmed with shares.remaining_required as sr %}
+                    Teile die restlichen benötigten {{ sr }} {{ v_share_pl }} unter dir und
                     deinen {{ v_co_member_pl }} auf.
                     {% endblocktrans %}
                 {% endif %}

--- a/juntagrico/templates/mails/admin/subscription_created.txt
+++ b/juntagrico/templates/mails/admin/subscription_created.txt
@@ -9,6 +9,7 @@
 
 {% trans "ID" %}: {{subscription.id}}
 {% trans "Beschrieb" %}: {{subscription}}
+{% trans "Kommentar" %}: {{comment}}
 {{ serverurl }}{% url 'admin:juntagrico_subscription_change' subscription.id %}
 
 {% blocktrans %}Liebe Grüsse und einen schönen Tag noch

--- a/juntagrico/util/management.py
+++ b/juntagrico/util/management.py
@@ -31,7 +31,8 @@ def new_signup(signup_data):
     # create subscription for member
     subscription = None
     if sum(signup_data.subscriptions.values()) > 0:
-        subscription = create_subscription(signup_data.start_date, signup_data.depot, signup_data.subscriptions, member)
+        subscription = create_subscription(signup_data.start_date, signup_data.depot, signup_data.subscriptions,
+                                           member, signup_data.main_member.comment)
 
     # add co-members
     for co_member in signup_data.co_members:
@@ -77,7 +78,7 @@ def create_share(member, amount=1):
         membernotification.shares_created(member, shares)
 
 
-def create_subscription(start_date, depot, subscription_types, member):
+def create_subscription(start_date, depot, subscription_types, member, comment=''):
     # create instance
     subscription = Subscription.objects.create(start_date=start_date, depot=depot)
     # add member
@@ -86,7 +87,7 @@ def create_subscription(start_date, depot, subscription_types, member):
     subscription.save()
     # set types
     create_subscription_parts(subscription, subscription_types)
-    adminnotification.subscription_created(subscription)
+    adminnotification.subscription_created(subscription, comment)
     return subscription
 
 

--- a/juntagrico/util/sessions.py
+++ b/juntagrico/util/sessions.py
@@ -113,7 +113,9 @@ class CSSessionObject(SessionObject):
             'existing_co_member': sum([len(co_member.usable_shares) for co_member in self.co_members]),
             'total_required': max(self.required_shares(), 1)
         }
-        shares['remaining_required'] = max(0, shares['total_required'] - max(0, shares['existing_main_member'] + shares['existing_co_member']))
+        shares['remaining_required'] = max(
+            0, shares['total_required'] - max(0, shares['existing_main_member'] + shares['existing_co_member'])
+        )
         return shares
 
     def evaluate_ordered_shares(self, shares=None):

--- a/juntagrico/view_decorators.py
+++ b/juntagrico/view_decorators.py
@@ -44,9 +44,12 @@ def create_subscription_session(view):
         som = SessionObjectManager(request, 'create_subscription', CSSessionObject)
         session_object = som.data
         # check if main member information is given. If not forward to first signup page.
+        is_signup = request.resolver_match.url_name == 'signup'
         if request.user.is_authenticated:
+            if not request.user.member.can_order_subscription and not is_signup:
+                return redirect('sub-detail')
             session_object.main_member = request.user.member
-        if session_object.main_member is None and request.resolver_match.url_name != 'signup':
+        if session_object.main_member is None and not is_signup:
             return redirect('signup')
         response = view(request, som.data, *args, **kwargs)
         som.store()

--- a/juntagrico/views_create_subscription.py
+++ b/juntagrico/views_create_subscription.py
@@ -199,7 +199,7 @@ class CSSummaryView(FormView):
         self.cs_session = None
 
     def get_initial(self):
-        return {'comment': self.cs_session.main_member.comment}
+        return {'comment': getattr(self.cs_session.main_member, 'comment', '')}
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(

--- a/juntagrico/views_subscription.py
+++ b/juntagrico/views_subscription.py
@@ -41,8 +41,6 @@ def subscription(request, subscription_id=None):
     '''
     member = request.user.member
     future_subscription = member.subscription_future is not None
-    can_order = member.subscription_future is None and (
-        member.subscription_current is None or member.subscription_current.cancellation_date is not None)
     if subscription_id is None:
         subscription = member.subscription_current
     else:
@@ -71,7 +69,7 @@ def subscription(request, subscription_id=None):
     renderdict.update({
         'no_subscription': subscription is None,
         'end_date': end_date,
-        'can_order': can_order,
+        'can_order': member.can_order_subscription,
         'future_subscription': future_subscription,
         'member': request.user.member,
         'shares': request.user.member.active_shares.count(),

--- a/test/test_comember.py
+++ b/test/test_comember.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from django.core import mail
 
 from juntagrico.models import Member, Share, Subscription
 from test.util.test import JuntagricoTestCase
@@ -11,6 +12,7 @@ class CoMemberTests(JuntagricoTestCase):
         self.member5 = self.create_member('email5@email.org')
         self.member5.iban = 'CH6189144414396247884'
         self.member5.save()
+        mail.outbox.clear()
 
     @staticmethod
     def get_co_member_data(email):
@@ -37,6 +39,8 @@ class CoMemberTests(JuntagricoTestCase):
         self.assertEqual(Member.objects.filter(email=new_co_member_data['email']).count(), 1)
         self.assertEqual(Share.objects.filter(member__email=new_co_member_data['email']).count(), 1)
         self.assertEqual(Subscription.objects.filter(subscriptionmembership__member__email=new_co_member_data['email']).count(), 1)
+        # membership and share order emails to co-member & admin notifications for the same
+        self.assertEqual(len(mail.outbox), 4)
 
     def testAddExistingCoMemberWithSub(self):
         # existing member with subs can not be added as co members

--- a/test/test_cs.py
+++ b/test/test_cs.py
@@ -101,6 +101,11 @@ class CreateSubscriptionTests(JuntagricoTestCase):
             }
         )
         self.assertRedirects(response, reverse('cs-co-members'))
+        co_member_data = new_member_data.copy()
+        co_member_data['email'] = 'test2@user.com'
+        response = self.client.post(reverse('cs-co-members'), co_member_data)
+        self.assertRedirects(response, reverse('cs-co-members'))
+        self.assertGet(reverse('cs-shares'), 200)
         response = self.client.post(
             reverse('cs-shares'),
             {
@@ -115,7 +120,7 @@ class CreateSubscriptionTests(JuntagricoTestCase):
         self.assertEqual(Member.objects.filter(email=new_member_data['email']).count(), 1)
         self.assertEqual(Share.objects.filter(member__email=new_member_data['email']).count(), 1)
         self.assertEqual(Subscription.objects.filter(primary_member__email=new_member_data['email']).count(), 1)
-        self.assertEqual(len(mail.outbox), 5)  # welcome mail, share mail & 3 admin notifications
+        self.assertEqual(len(mail.outbox), 7)  # welcome mail, share mail & same for co-member & 3 admin notifications
         # first mail should be admin notification
         if with_comment:
             self.assertIn(test_comment, mail.outbox[0].body)

--- a/test/test_cs.py
+++ b/test/test_cs.py
@@ -7,51 +7,9 @@ from test.util.test import JuntagricoTestCase
 
 
 class CreateSubscriptionTests(JuntagricoTestCase):
-
-    def testSignupLogout(self):
-        self.client.force_login(self.member.user)
-        user = auth.get_user(self.client)
-        assert user.is_authenticated
-        self.client.get('/my/signup/')
-        self.assertEqual(str(auth.get_user(self.client)), 'AnonymousUser')
-
-    def testRedirect(self):
-        response = self.client.get(reverse('cs-subscription'))
-        self.assertEqual(response.status_code, 302)
-        response = self.client.post(reverse('cs-subscription'))
-        self.assertEqual(response.status_code, 302)
-
-        response = self.client.get(reverse('cs-depot'))
-        self.assertEqual(response.status_code, 302)
-        response = self.client.post(reverse('cs-depot'))
-        self.assertEqual(response.status_code, 302)
-
-        response = self.client.get(reverse('cs-start'))
-        self.assertEqual(response.status_code, 302)
-        response = self.client.post(reverse('cs-start'))
-        self.assertEqual(response.status_code, 302)
-
-        response = self.client.get(reverse('cs-co-members'))
-        self.assertEqual(response.status_code, 302)
-        response = self.client.post(reverse('cs-co-members'))
-        self.assertEqual(response.status_code, 302)
-
-        response = self.client.get(reverse('cs-shares'))
-        self.assertEqual(response.status_code, 302)
-        response = self.client.post(reverse('cs-shares'))
-        self.assertEqual(response.status_code, 302)
-
-        response = self.client.get(reverse('cs-summary'))
-        self.assertEqual(response.status_code, 302)
-        response = self.client.post(reverse('cs-summary'))
-        self.assertEqual(response.status_code, 302)
-
-    def testWelcome(self):
-        response = self.client.get(reverse('welcome'))
-        self.assertEqual(response.status_code, 200)
-
-    def commonSignupTest(self, with_comment=False):
-        new_member_data = {
+    @staticmethod
+    def newMemberData(email='test@user.com'):
+        return {
             'last_name': 'Last Name',
             'first_name': 'First Name',
             'addr_street': 'Street',
@@ -59,14 +17,35 @@ class CreateSubscriptionTests(JuntagricoTestCase):
             'addr_location': 'Zurich',
             'phone': '044',
             'mobile_phone': '',
-            'email': 'test@user.com',
+            'email': email,
             'birthday': '',
             'agb': 'on'
         }
-        if with_comment:
-            new_member_data['comment'] = 'Short comment'
-        response = self.client.post(reverse('signup'), new_member_data)
-        self.assertRedirects(response, reverse('cs-subscription'))
+
+    def assertGet(self, url, code=302, member=None):
+        """ Stay logged out
+        """
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, code)
+        return response
+
+    def assertPost(self, url, data=None, code=302, member=None):
+        """ Stay logged out
+        """
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, code)
+        return response
+
+    def assertGetAndPost(self, url, code=302):
+        self.assertGet(reverse(url), code)
+        self.assertPost(reverse(url), code)
+
+    def assertGetAndRedirects(self, get, redirect='sub-detail'):
+        response = self.client.get(reverse(get))
+        self.assertRedirects(response, reverse(redirect))
+
+    def commonAddSub(self, member_email, comment='', comment_in=0):
+        initial_share_count = Share.objects.filter(member__email=member_email).count()
         response = self.client.post(
             reverse('cs-subscription'),
             {
@@ -90,8 +69,7 @@ class CreateSubscriptionTests(JuntagricoTestCase):
             }
         )
         self.assertRedirects(response, reverse('cs-co-members'))
-        co_member_data = new_member_data.copy()
-        co_member_data['email'] = 'test2@user.com'
+        co_member_data = self.newMemberData('test2@user.com')
         response = self.client.post(reverse('cs-co-members'), co_member_data)
         self.assertRedirects(response, reverse('cs-co-members'))
         self.assertGet(reverse('cs-shares'), 200)
@@ -103,21 +81,65 @@ class CreateSubscriptionTests(JuntagricoTestCase):
         )
         self.assertRedirects(response, reverse('cs-summary'))
         # confirm summary
-        test_comment = 'new test comment'
-        response = self.client.post(reverse('cs-summary'), {'comment': test_comment if with_comment else ''})
+        response = self.client.post(reverse('cs-summary'), {'comment': comment})
         self.assertRedirects(response, reverse('welcome-with-sub'))
-        self.assertEqual(Member.objects.filter(email=new_member_data['email']).count(), 1)
-        self.assertEqual(Share.objects.filter(member__email=new_member_data['email']).count(), 1)
-        self.assertEqual(Subscription.objects.filter(primary_member__email=new_member_data['email']).count(), 1)
-        self.assertEqual(len(mail.outbox), 7)  # welcome mail, share mail & same for co-member & 3 admin notifications
-        # first mail should be admin notification
+        self.assertEqual(Member.objects.filter(email=member_email).count(), 1)
+        self.assertEqual(Share.objects.filter(member__email=member_email).count(), initial_share_count + 1)
+        self.assertEqual(Subscription.objects.filter(primary_member__email=member_email).count(), 1)
+        # look for comment in admin notification
+        self.assertIn(comment, mail.outbox[comment_in].body)
+
+    def commonSignupTest(self, with_comment=False):
+        new_member_data = self.newMemberData()
         if with_comment:
-            self.assertIn(test_comment, mail.outbox[0].body)
+            new_member_data['comment'] = 'Short comment'
+        response = self.client.post(reverse('signup'), new_member_data)
+        self.assertRedirects(response, reverse('cs-subscription'))
+        self.commonAddSub(new_member_data['email'], 'new test comment' if with_comment else '')
+        self.assertEqual(len(mail.outbox), 7)  # welcome mail, share mail & same for co-member & 3 admin notifications
 
         # signup with different case email address should fail
         new_member_data['email'] = 'Test@user.com'
         response = self.client.post(reverse('signup'), new_member_data)
         self.assertEqual(response.status_code, 200)  # no redirect = failed
+
+    def testSignupLogout(self):
+        self.client.force_login(self.member.user)
+        user = auth.get_user(self.client)
+        assert user.is_authenticated
+        self.client.get(reverse('signup'))
+        self.assertEqual(str(auth.get_user(self.client)), 'AnonymousUser')
+
+    def testRedirect(self):
+        self.assertGetAndPost('cs-subscription')
+        self.assertGetAndPost('cs-depot')
+        self.assertGetAndPost('cs-start')
+        self.assertGetAndPost('cs-co-members')
+        self.assertGetAndPost('cs-shares')
+        self.assertGetAndPost('cs-summary')
+
+    def testWelcome(self):
+        response = self.client.get(reverse('welcome'))
+        self.assertEqual(response.status_code, 200)
+
+    def testAddSubWithExistingSub(self):
+        """ subscription creation form should be inaccessible, for members with a subscription
+        """
+        self.client.force_login(self.member.user)
+        self.assertGetAndRedirects('cs-subscription')
+        self.assertGetAndRedirects('cs-depot')
+        self.assertGetAndRedirects('cs-start')
+        self.assertGetAndRedirects('cs-co-members')
+        self.assertGetAndRedirects('cs-shares')
+        self.assertGetAndRedirects('cs-summary')
+
+    def testAddSub(self):
+        """ test order of new sub by existing member without sub
+        """
+        self.client.force_login(self.member4.user)
+        self.commonAddSub(self.member4.email, 'test comment', 2)
+        # share mail for member & welcome mail for co-member & 3 admin notifications
+        self.assertEqual(len(mail.outbox), 5)
 
     def testSignupWithComment(self):
         self.commonSignupTest(True)

--- a/test/test_cs.py
+++ b/test/test_cs.py
@@ -1,5 +1,4 @@
 from django.contrib import auth
-from django.contrib.auth.models import Permission
 from django.core import mail
 from django.urls import reverse
 
@@ -8,16 +7,6 @@ from test.util.test import JuntagricoTestCase
 
 
 class CreateSubscriptionTests(JuntagricoTestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.member.user.user_permissions.add(
-            Permission.objects.get(codename='notified_on_subscription_creation'))
-        self.member.user.user_permissions.add(
-            Permission.objects.get(codename='notified_on_member_creation'))
-        self.member.user.user_permissions.add(
-            Permission.objects.get(codename='notified_on_share_creation'))
-        self.member.user.save()
 
     def testSignupLogout(self):
         self.client.force_login(self.member.user)

--- a/test/util/test.py
+++ b/test/util/test.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import Permission
 from django.test import TestCase, override_settings
 from django.utils import timezone
+from django.core import mail
 
 from juntagrico.entity.delivery import Delivery, DeliveryItem
 from juntagrico.entity.depot import Depot
@@ -28,6 +29,7 @@ class JuntagricoTestCase(TestCase):
         self.set_up_extra_sub()
         self.set_up_mail_template()
         self.set_up_deliveries()
+        mail.outbox.clear()
 
     @staticmethod
     def create_member(email):
@@ -84,6 +86,12 @@ class JuntagricoTestCase(TestCase):
             Permission.objects.get(codename='can_load_templates'))
         self.member.user.user_permissions.add(
             Permission.objects.get(codename='change_subscriptionpart'))
+        self.member.user.user_permissions.add(
+            Permission.objects.get(codename='notified_on_subscription_creation'))
+        self.member.user.user_permissions.add(
+            Permission.objects.get(codename='notified_on_member_creation'))
+        self.member.user.user_permissions.add(
+            Permission.objects.get(codename='notified_on_share_creation'))
         self.member.user.save()
 
     def set_up_admin(self):


### PR DESCRIPTION
Fix some missing template variables and follow up issues after extending the tests.

Most critical is a fix in the order process of a sub for an existing member, that would lead to a 500 error on the summary page, due to the comment that is now expected on that form.
Instead of removing the comment field in that case, I included the comment in the admin notification mail for the new subscription. For the full signup process the comment will now appear in both emails (member and subscription creation notification), which is fine, because member could signup without a subscription and comment could be relevant for both.

In addition I blocked existing members with subscription from accessing the subscription order form. Trying to do the order process would result in a 500 error at the end and would puzzle the members, admins and troubleshooters (aka us).

Tests for signup and subscription order now cover more cases:
- new member signup (with or without writing a comment in the comment field)
- trying to signup with the same email but different letter case.
- order of subscription of an existing member (with and without existing subcription)