### PR TITLE
calculate_next should not include today

### DIFF
--- a/juntagrico/util/temporal.py
+++ b/juntagrico/util/temporal.py
@@ -98,25 +98,15 @@ def next_membership_end_date():
 
 
 def calculate_next(day, month):
-    now = timezone.now()
-    if now.month < month or (now.month == month and now.day <= day):
-        year = now.year
-    else:
-        year = now.year + 1
-    return datetime.date(year, month, day)
+    return calculate_next_offset(day, month, timezone.now())
 
 
 def calculate_last(day, month):
-    now = timezone.now()
-    if now.month > month or (now.month == month and now.day >= day):
-        year = now.year
-    else:
-        year = now.year - 1
-    return datetime.date(year, month, day)
+    return calculate_last_offset(day, month, timezone.now())
 
 
 def calculate_next_offset(day, month, offset):
-    if offset.month < month or (offset.month == month and offset.day <= day):
+    if offset.month < month or (offset.month == month and offset.day < day):
         year = offset.year
     else:
         year = offset.year + 1


### PR DESCRIPTION
Otherwise the first day of the business year would be treated differently from the second and following days.

Also reduced code duplication