### PR TITLE
#447 show subscription min duration in order process

### DIFF
--- a/docs/1_4_release_notes.rst
+++ b/docs/1_4_release_notes.rst
@@ -4,6 +4,12 @@ Release Notes
 Dev
 ---
 
+Features & Improvements
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* Member Features:
+    * Show minimum subscription duration in share order process
+
 Fixes
 ^^^^^
 * Fix export of share payment file (pain.001)

--- a/juntagrico/entity/subtypes.py
+++ b/juntagrico/entity/subtypes.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext as _
 
 from juntagrico.config import Config
 from juntagrico.entity import JuntagricoBaseModel
+from juntagrico.util import temporal
 
 
 class SubscriptionProduct(JuntagricoBaseModel):
@@ -78,6 +79,14 @@ class SubscriptionType(JuntagricoBaseModel):
     @property
     def has_periods(self):
         return self.periods.count() > 0
+
+    def min_duration_info(self):
+        if self.trial_days:
+            return _('{} Tage. Keine automatische Verlängerung.').format(self.trial_days)
+        if self.has_periods:
+            return None  # price list already shows end of periods
+        date = temporal.end_of_business_year()
+        return _('Bis {day}.{month}. Automatische Verlängerung.').format(day=date.day, month=date.month)
 
     @property
     def display_name(self):

--- a/juntagrico/templates/createsubscription/summary.html
+++ b/juntagrico/templates/createsubscription/summary.html
@@ -36,9 +36,19 @@
         <h4>{{ v_subscription }} <a href="{% url 'cs-subscription' %}" class="edit"><i class="fas fa-pen"></i></a></h4>
         <p>
         {% for type, amount in subscriptions.items %}
-            {%blocktrans trimmed with tn=type.name tp=type.price%}
-            <b>{{ amount }}</b>&times; {{ tn }} à {{ c_currency }} {{ tp }}/Jahr
-            {%endblocktrans%}
+            <strong>{{ amount }}</strong>&times; {{ type.name }}
+            {% if type.has_periods %}
+                {% for period in type.periods.all %}
+                    <br/>
+                    {{ period.start_day }}.{{ period.start_month }}. - {{ period.end_day }}.{{ period.end_month }}.
+                    {{ period.price }} {% config "currency" %}
+                {% endfor %}
+            {% else %}
+                {%blocktrans with tp=type.price%}
+                 à {{ c_currency }} {{ tp }}/Jahr.
+                {%endblocktrans%}
+                {{ type.min_duration_info }}
+            {% endif %}
             {% if not forloop.last %}<br>{% endif %}
         {% endfor %}
         {% if subscriptions|length == 0 %}

--- a/juntagrico/templates/forms/subscription_type_field.html
+++ b/juntagrico/templates/forms/subscription_type_field.html
@@ -24,6 +24,8 @@
             {% endfor %}
         {% else %}
             {% vocabulary "price" %}: {{ type.price }} {% config "currency" %}
+            <br/>
+            {% trans "Laufzeit" %}: {{ type.min_duration_info }}
         {% endif %}
         {% config "enable_shares" as c_enable_shares %}
         {% if c_enable_shares %}


### PR DESCRIPTION
resolves #447

I consider the trial subscription field in this implementation. The trial field has been hidden in the admin (in 1.3), but the trial duration was not. I think the trial field is not needed, it can be just trial duration != 0.

Also fixes the summary page, where subs with billing periods showed the wrong price.