### PR TITLE
#411 textoverride poc

### DIFF
--- a/juntagrico/admin.py
+++ b/juntagrico/admin.py
@@ -14,6 +14,7 @@ from juntagrico.admins.share_admin import ShareAdmin
 from juntagrico.admins.subscription_admin import SubscriptionAdmin
 from juntagrico.admins.subscription_type_admin import SubscriptionTypeAdmin, SubscriptionSizeAdmin, \
     SubscriptionProductAdmin
+from juntagrico.admins.text_override_admin import TextOverrideAdmin
 from juntagrico.config import Config
 from juntagrico.entity.billing import BillingPeriod
 from juntagrico.entity.delivery import Delivery
@@ -25,6 +26,7 @@ from juntagrico.entity.member import Member, SubscriptionMembership
 from juntagrico.entity.share import Share
 from juntagrico.entity.subs import Subscription
 from juntagrico.entity.subtypes import SubscriptionSize, SubscriptionType, SubscriptionProduct
+from juntagrico.entity.textoverride import TextOverride
 from juntagrico.util import addons
 
 # loading addons here so that we have the information about admin extensions stuff like inlines etc
@@ -50,3 +52,4 @@ admin.site.register(ListMessage, ListMessageAdmin)
 admin.site.register(BillingPeriod, BaseAdmin)
 if Config.enable_shares():
     admin.site.register(Share, ShareAdmin)
+admin.site.register(TextOverride, TextOverrideAdmin)

--- a/juntagrico/admins/text_override_admin.py
+++ b/juntagrico/admins/text_override_admin.py
@@ -1,0 +1,20 @@
+from juntagrico.admins import BaseAdmin
+
+
+class TextOverrideAdmin(BaseAdmin):
+    list_display = ['name']
+    fields = ['name', 'text']
+
+    def get_fields(self, request, obj=None):
+        """ on object creation only text to override can be selected.
+        """
+        if not obj:
+            return ['name']
+        return super().get_fields(request, obj)
+
+    def get_readonly_fields(self, request, obj=None):
+        """ text selection can not be changed once the object is created.
+        """
+        if obj:
+            return ['name']
+        return super().get_readonly_fields(request, obj)

--- a/juntagrico/entity/textoverride.py
+++ b/juntagrico/entity/textoverride.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from django.db import models
+from django.template.loader import get_template
+from django.utils.translation import gettext as _
+
+from juntagrico.entity import JuntagricoBaseModel
+
+
+def get_overridable_templates():
+    """ collets the overridable templates from the textsnippets folder
+    :return: an iterable of tuples with the relative paths to overridable text templates and its file name
+    """
+    local_templates = Path(__file__).parent.parent / 'templates'
+    text_templates = local_templates / 'textsnippets'
+    for path in text_templates.glob('*'):
+        yield path.relative_to(local_templates).as_posix(), path.relative_to(text_templates).as_posix()
+
+
+class TextOverride(JuntagricoBaseModel):
+    """
+    Template text overrides
+    """
+    name = models.CharField(_('Name'), max_length=100, unique=True, choices=get_overridable_templates())
+    text = models.TextField(_('Text'), max_length=3000, blank=True)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        verbose_name = _('Textanpassung')
+        verbose_name_plural = _('Textanpassungen')
+
+
+def pre_save(sender, instance, **kwds):
+    """ on creation the overridden text is populated with the default text
+    """
+    if not instance.pk:
+        instance.text = get_template(instance.name).template.source

--- a/juntagrico/models.py
+++ b/juntagrico/models.py
@@ -9,6 +9,7 @@ from juntagrico.entity.jobs import Assignment, OneTimeJob, RecuringJob, Job
 from juntagrico.entity.member import Member, SubscriptionMembership
 from juntagrico.entity.share import Share
 from juntagrico.entity.subs import Subscription, SubscriptionPart
+from juntagrico.entity.textoverride import TextOverride, pre_save as textoverride_pre_save
 from juntagrico.lifecycle.job import job_pre_save, handle_job_canceled, handle_job_time_changed
 from juntagrico.lifecycle.member import member_pre_save, member_post_save, handle_member_deactivated, \
     handle_member_created
@@ -73,6 +74,8 @@ signals.pre_save.connect(member_pre_save, sender=Member)
 signals.post_save.connect(member_post_save, sender=Member)
 juntagrico.signals.member_created.connect(handle_member_created, sender=Member)
 juntagrico.signals.member_deactivated.connect(handle_member_deactivated, sender=Member)
+''' text override init '''
+signals.pre_save.connect(textoverride_pre_save, sender=TextOverride)
 ''' lifecycle all post init'''
 register_entities_for_post_init_and_save()
 

--- a/juntagrico/static/juntagrico/css/juntagrico.css
+++ b/juntagrico/static/juntagrico/css/juntagrico.css
@@ -393,3 +393,8 @@ th {
 .cc-btn{
     font-size: 0.875rem;
 }
+
+/* text overrides */
+.hide-if-empty:empty {
+    display: none;
+}

--- a/juntagrico/templateloaders/textoverride.py
+++ b/juntagrico/templateloaders/textoverride.py
@@ -1,0 +1,26 @@
+"""
+Wrapper for loading templates from the database.
+"""
+
+from django.template import Origin, TemplateDoesNotExist
+
+from django.template.loaders.base import Loader as BaseLoader
+
+from juntagrico.entity.textoverride import TextOverride
+
+
+class Loader(BaseLoader):
+
+    def get_contents(self, origin):
+        try:
+            text = TextOverride.objects.get(name__exact=origin.template_name)
+        except TextOverride.DoesNotExist:
+            raise TemplateDoesNotExist(origin)
+        return text.text
+
+    def get_template_sources(self, template_name, template_dirs=None):
+        yield Origin(
+            name=template_name,
+            template_name=template_name,
+            loader=self,
+        )

--- a/juntagrico/templates/areas.html
+++ b/juntagrico/templates/areas.html
@@ -7,24 +7,11 @@
     </h3>
 {% endblock %}
 {% block content %}
-    {% enriched_organisation "D" as v_d_enriched_organisation %}
     <div class="row">
         <div class="col-md-12">
-            {% blocktrans trimmed%}
-            Wer bei {{ v_d_enriched_organisation }} mitmacht verpflichtet sich, im Rahmen der eigenen
-            Motivationen, Prioritäten und Möglichkeiten gemeinsam zum Gelingen des Betriebes beizutragen.
-            {% endblocktrans %}
-            <br/>
-            {% trans "Trage dich für die Tätigkeitsbereiche ein, in denen du regelmässig Mitarbeiten und Verantwortung übernehmen möchtest." %}
-            <br/>
+            {% enriched_organisation "D" as v_d_enriched_organisation %}
             {% config "activity_area_info" as activity_area_info %}
-            {% if activity_area_info.strip %}
-                {% trans "Infos zu den Tätigkeitsbereichen erhältst du im" %}
-                <a target="_blank" href="{{ activity_area_info }}">
-                    {% trans "Infoblatt" %}
-                </a>
-                .
-            {% endif %}
+            {% include "textsnippets/areas_intro.html" %}
             <br/>
 
     <div class="row">

--- a/juntagrico/templates/createsubscription/add_member_cs.html
+++ b/juntagrico/templates/createsubscription/add_member_cs.html
@@ -19,16 +19,7 @@
     <div class="offset-md-2 col-md-8">
         <div class="row mb-4">
             <div class="col-md-12">
-                {% blocktrans trimmed %}
-                Du kannst weitere {{ v_subscription }}-BezieherInnen als {{ v_co_member }} hinzufügen. Fülle bitte die
-                untenstehenden Felder aus
-                und klicke anschliessend auf "{{ v_co_member }} hinzufügen".
-                {% endblocktrans %}
-                <br/>
-                {% blocktrans trimmed %}
-                Falls du keine {{ v_co_member_pl }} hinzufügen möchtest, klicke auf "Überspringen".<br>
-                Wenn du alle {{ v_co_member_pl }} hinzugefügt hast, klicke auf "Keine weiteren {{ v_co_member_pl }} hinzufügen".
-                {% endblocktrans %}
+                {% include 'textsnippets/add_member_cs_intro.html' %}
             </div>
         </div>
 

--- a/juntagrico/templates/createsubscription/select_depot.html
+++ b/juntagrico/templates/createsubscription/select_depot.html
@@ -34,7 +34,7 @@
             </div>
             <div id="depot_container" class="form-group row">
                 <label for="depot" class="offset-md-3 col-md-9">
-                    {% blocktrans %}Wähle 1 {{ v_depot }} als {{ v_subscription }}-Abholort aus.{% endblocktrans %}
+                    {% include "textsnippets/select_depot_description.html" %}
                 </label>
             </div>
             <div id="depot_container" class="form-group row">

--- a/juntagrico/templates/createsubscription/select_shares.html
+++ b/juntagrico/templates/createsubscription/select_shares.html
@@ -30,32 +30,7 @@
         {% endif %}
         <div class="row mb-4">
             <div class="col-md-12">
-                {% trans "Infos" %}:
-                {% blocktrans trimmed %}
-                Um {{ v_member_type }} bei {{ v_d_enriched_organisation }} zu werden, musst du mindestens
-                1 {{ v_share }} ({{ c_currency }} {{ c_share_price }}) erwerben.
-                Beim Austritt aus {{ v_d_enriched_organisation }} bekommst du deine {{ v_share_pl }}
-                zurückerstattet.
-                {% endblocktrans %}
-                {% if shares.total_required > 0 %}
-                    {% blocktrans trimmed with shares.total_required as st %}
-                    Für die von dir ausgewählten {{ v_subscription }}-Bestandteile brauchst du insgesamt {{ st }}
-                    {{ v_share_pl }}. Du kannst natürlich noch mehr erwerben.
-                    {% endblocktrans %}
-                    <br/>
-                {% else %}
-                    {% blocktrans trimmed %}
-                    Als {{ v_member_type }} ohne {{ v_subscription }} benötigst du 1
-                    {{ v_share }}. Du kannst natürlich noch mehr erwerben.
-                    {% endblocktrans %}
-                    <br/>
-                {% endif %}
-                {% if co_members|length > 0 %}
-                    {% blocktrans trimmed with shares.remaining_required as sr %}
-                    Teile die restlichen benötigten {{ sr }} {{ v_share_pl }} unter dir und
-                    deinen {{ v_co_member_pl }} auf.
-                    {% endblocktrans %}
-                {% endif %}
+                {% include 'textsnippets/select_shares_intro.html' %}
             </div>
         </div>
         <form action="" method="post">

--- a/juntagrico/templates/createsubscription/select_start_date.html
+++ b/juntagrico/templates/createsubscription/select_start_date.html
@@ -13,29 +13,19 @@
     <div class="offset-md-2 col-md-8">
         <div class="row mb-4">
             <div class="col-md-12">
-                {% trans "Info" %}:
-                {% blocktrans trimmed with sd=start_date|date:"d.m.Y" %}
-                Normalerweise ist der {{ v_subscription }}-Start der Start eines Geschäftsjahres. Das nächste
-                Startdatum wäre der <b>{{ sd }}</b>.
-                Es kann jedoch vorkommen, dass unter dem Jahr 1 {{ v_subscription }} frei wird. Würdest du
-                gerne schon früher einsteigen falls 1 {{ v_subscription }} frei wird, dann kannst du das
-                Startdatum unten anpassen.
-                {% endblocktrans %}
+                {% include 'textsnippets/select_start_date_intro.html' %}
             </div>
         </div>
         <form action="" method="post">
             {% csrf_token %}
             <div id="start_date" class="form-group row">
                 <label class="col-md-3">
-                    {% trans "Gewünschtes Startdatum" %}
+                    {% include 'textsnippets/select_start_date_label.html' %}
                 </label>
                 <div class="col-md-9">
                     <label>
                         {{ subscriptionform.start_date }}
-                        {% blocktrans trimmed %}
-                        Gilt nur insofern 1 {{ v_subscription }}
-                        zum gewünschten Datum frei ist.
-                        {% endblocktrans %}
+                        {% include 'textsnippets/select_start_date_description.html' %}
                     </label>
                     {% if subscriptionform.start_date.errors %}
                         <div class="alert alert-danger">

--- a/juntagrico/templates/createsubscription/select_subscription.html
+++ b/juntagrico/templates/createsubscription/select_subscription.html
@@ -11,6 +11,7 @@
     </div>
 {% endblock %}
 {% block allcontent %}
+    <div class="offset-md-2 col-md-8 mb-4 hide-if-empty">{% include "textsnippets/select_subscription_intro.html" %}</div>
     <div class="offset-md-2 col-md-8">
         {% crispy form %}
     </div>

--- a/juntagrico/templates/signup.html
+++ b/juntagrico/templates/signup.html
@@ -25,32 +25,7 @@
         {% vocabulary "member_type_pl" as v_member_type_pl %}
         <div class="row mb-3">
             <div class="col-md-12">
-                Interessiert an {% enriched_organisation "D" %}?
-            </div>
-        </div>
-        {% if c_enable_shares %}
-            <div class="row mb-3">
-                <div class="col-md-12">
-                    {% blocktrans trimmed %}
-                    Die Mitgliedschaft bei {{ v_d_enriched_organisation }} ist geknüpft an den Erwerb von
-                    {{ v_share_pl }} in der Höhe
-                    von CHF {{ c_share_price }} pro {{ v_share }}. Die Anzahl {{ v_share_pl }}
-                    ist abhängig von den {{ v_subscription }}-Bestandteilen. Die {{ v_share_pl }} sind das
-                    Kapital, das vor allem zur Finanzierung von Investitionen – zum Beispiel Infrastruktur – verwendet
-                    wird.
-                    Beim Austritt werden die {{ v_share_pl }} rückerstattet.
-                    {% endblocktrans %}
-                </div>
-            </div>
-        {% endif %}
-        <div class="row mb-3">
-            <div class="col-md-12">
-                {% blocktrans trimmed %}
-                Die {{ v_member_type_pl }} tragen im Rahmen ihrer Motivationen, Prioritäten und Möglichkeiten
-                gemeinsam zum Gelingen des Betriebes bei.
-                Wer bei {{ v_d_enriched_organisation }} {{ v_member_type }} ist, verpflichtet sich zur
-                Mitarbeit. Zusätzliches wie auch spontanes Engagement ist jederzeit willkommen.
-                {% endblocktrans %}
+                {% include "textsnippets/signup_intro.html" %}
             </div>
         </div>
         {% if c_bylaws.strip or c_business_regulations.strip %}

--- a/juntagrico/templates/textsnippets/add_member_cs_intro.html
+++ b/juntagrico/templates/textsnippets/add_member_cs_intro.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+{% blocktrans trimmed %}
+Du kannst weitere {{ v_subscription }}-BezieherInnen als {{ v_co_member }} hinzufügen. Fülle bitte die
+untenstehenden Felder aus
+und klicke anschliessend auf "{{ v_co_member }} hinzufügen".
+{% endblocktrans %}
+<br/>
+{% blocktrans trimmed %}
+Falls du keine {{ v_co_member_pl }} hinzufügen möchtest, klicke auf "Überspringen".<br>
+Wenn du alle {{ v_co_member_pl }} hinzugefügt hast, klicke auf "Keine weiteren {{ v_co_member_pl }} hinzufügen".
+{% endblocktrans %}

--- a/juntagrico/templates/textsnippets/areas_intro.html
+++ b/juntagrico/templates/textsnippets/areas_intro.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% blocktrans trimmed %}
+Wer bei {{ v_d_enriched_organisation }} mitmacht verpflichtet sich, im Rahmen der eigenen
+Motivationen, Prioritäten und Möglichkeiten gemeinsam zum Gelingen des Betriebes beizutragen.
+{% endblocktrans %}
+<br/>
+{% trans "Trage dich für die Tätigkeitsbereiche ein, in denen du regelmässig Mitarbeiten und Verantwortung übernehmen möchtest." %}
+{% if activity_area_info.strip %}
+    <br/>
+    {% trans "Infos zu den Tätigkeitsbereichen erhältst du im" %}
+    <a target="_blank" href="{{ activity_area_info }}">{% trans "Infoblatt" %}</a>.
+{% endif %}

--- a/juntagrico/templates/textsnippets/select_depot_description.html
+++ b/juntagrico/templates/textsnippets/select_depot_description.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}Wähle 1 {{ v_depot }} als {{ v_subscription }}-Abholort aus.{% endblocktrans %}

--- a/juntagrico/templates/textsnippets/select_shares_intro.html
+++ b/juntagrico/templates/textsnippets/select_shares_intro.html
@@ -1,0 +1,27 @@
+{% load i18n %}
+{% trans "Infos" %}:
+{% blocktrans trimmed %}
+Um {{ v_member_type }} bei {{ v_d_enriched_organisation }} zu werden, musst du mindestens
+1 {{ v_share }} ({{ c_currency }} {{ c_share_price }}) erwerben.
+Beim Austritt aus {{ v_d_enriched_organisation }} bekommst du deine {{ v_share_pl }}
+zurückerstattet.
+{% endblocktrans %}
+{% if shares.total_required > 0 %}
+    {% blocktrans trimmed with shares.total_required as st %}
+    Für die von dir ausgewählten {{ v_subscription }}-Bestandteile brauchst du insgesamt {{ st }}
+    {{ v_share_pl }}. Du kannst natürlich noch mehr erwerben.
+    {% endblocktrans %}
+    <br/>
+{% else %}
+    {% blocktrans trimmed %}
+    Als {{ v_member_type }} ohne {{ v_subscription }} benötigst du 1
+    {{ v_share }}. Du kannst natürlich noch mehr erwerben.
+    {% endblocktrans %}
+    <br/>
+{% endif %}
+{% if co_members|length > 0 %}
+    {% blocktrans trimmed with shares.remaining_required as sr %}
+    Teile die restlichen benötigten {{ sr }} {{ v_share_pl }} unter dir und
+    deinen {{ v_co_member_pl }} auf.
+    {% endblocktrans %}
+{% endif %}

--- a/juntagrico/templates/textsnippets/select_start_date_description.html
+++ b/juntagrico/templates/textsnippets/select_start_date_description.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% blocktrans trimmed %}
+Gilt nur insofern 1 {{ v_subscription }} zum gewünschten Datum frei ist.
+{% endblocktrans %}

--- a/juntagrico/templates/textsnippets/select_start_date_intro.html
+++ b/juntagrico/templates/textsnippets/select_start_date_intro.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+{% trans "Info" %}:
+{% blocktrans trimmed with sd=start_date|date:"d.m.Y" %}
+Normalerweise ist der {{ v_subscription }}-Start der Start eines Geschäftsjahres. Das nächste
+Startdatum wäre der <strong>{{ sd }}</strong>.
+Es kann jedoch vorkommen, dass unter dem Jahr 1 {{ v_subscription }} frei wird. Würdest du
+gerne schon früher einsteigen falls 1 {{ v_subscription }} frei wird, dann kannst du das
+Startdatum unten anpassen.
+{% endblocktrans %}

--- a/juntagrico/templates/textsnippets/select_start_date_label.html
+++ b/juntagrico/templates/textsnippets/select_start_date_label.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% trans "Gewünschtes Startdatum" %}

--- a/juntagrico/templates/textsnippets/signup_intro.html
+++ b/juntagrico/templates/textsnippets/signup_intro.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+<p>Interessiert an {{ v_d_enriched_organisation }}?</p>
+{% if c_enable_shares %}
+    <p>
+        {% blocktrans trimmed %}
+        Die Mitgliedschaft bei {{ v_d_enriched_organisation }} ist geknüpft an den Erwerb von
+        {{ v_share_pl }} in der Höhe
+        von CHF {{ c_share_price }} pro {{ v_share }}. Die Anzahl {{ v_share_pl }}
+        ist abhängig von den {{ v_subscription }}-Bestandteilen. Die {{ v_share_pl }} sind das
+        Kapital, das vor allem zur Finanzierung von Investitionen – zum Beispiel Infrastruktur – verwendet
+        wird.
+        Beim Austritt werden die {{ v_share_pl }} rückerstattet.
+        {% endblocktrans %}
+    </p>
+{% endif %}
+<p>
+    {% blocktrans trimmed %}
+    Die {{ v_member_type_pl }} tragen im Rahmen ihrer Motivationen, Prioritäten und Möglichkeiten
+    gemeinsam zum Gelingen des Betriebes bei.
+    Wer bei {{ v_d_enriched_organisation }} {{ v_member_type }} ist, verpflichtet sich zur
+    Mitarbeit. Zusätzliches wie auch spontanes Engagement ist jederzeit willkommen.
+    {% endblocktrans %}
+</p>

--- a/juntagrico/templates/textsnippets/welcome_message.html
+++ b/juntagrico/templates/textsnippets/welcome_message.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% blocktrans %}Du bist jetzt {{ v_member_type }} bei {{ v_d_enriched_organisation }}.{% endblocktrans %}
+{% if not no_subscription %}
+    {% blocktrans %}Du wurdest als {{ v_subscription }}-BezieherIn zur Warteliste hinzugefügt.{% endblocktrans %}
+{% endif %}
+{% trans "Du erhälst eine Email mit allen weiteren Infos an die von dir angegebene Emailadresse ( unsere Mails verirren sich manchmal in den SPAM Ordner )." %}

--- a/juntagrico/templates/welcome.html
+++ b/juntagrico/templates/welcome.html
@@ -9,11 +9,9 @@
 {% endblock %}
 {% block allcontent %}
     <div class="alert alert-success">
-        {% enriched_organisation "D" as v_d_enriched_organisation %} {% vocabulary "member_type" as v_member_type %} {% vocabulary "subscription" as v_subscription %}
-        {% blocktrans %}Du bist jetzt {{ v_member_type }} bei {{ v_d_enriched_organisation }}.{% endblocktrans %}
-        {% if not no_subscription %}
-            {% blocktrans %}Du wurdest als {{ v_subscription }}-BezieherIn zur Warteliste hinzugefügt.{% endblocktrans %}
-        {% endif %}
-        {% trans "Du erhälst eine Email mit allen weiteren Infos an die von dir angegebene Emailadresse ( unsere Mails verirren sich manchmal in den SPAM Ordner )." %}
+        {% enriched_organisation "D" as v_d_enriched_organisation %}
+        {% vocabulary "member_type" as v_member_type %}
+        {% vocabulary "subscription" as v_subscription %}
+        {% include 'textsnippets/welcome_message.html' %}
     </div>
 {% endblock %}

--- a/testsettings.py
+++ b/testsettings.py
@@ -115,6 +115,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
             ],
             'loaders': [
+                'juntagrico.templateloaders.textoverride.Loader',
                 'django.template.loaders.filesystem.Loader',
                 'django.template.loaders.app_directories.Loader'
             ],


### PR DESCRIPTION
proof of concept

Allows to define template overrides in the database.
In theory all templates could be overridden that way. For now it is limited to some text snippets selected in #411

If performance turns out to be an issue, some simple caching could be implemented

Note that the feature can be disabled by not adding the template loader.