### PR TITLE
Setting to override tinymce options of mailer view

### DIFF
--- a/docs/1_5_release_notes.rst
+++ b/docs/1_5_release_notes.rst
@@ -26,6 +26,7 @@ Features & Improvements
 * Developer Features:
     * ``ADMINPORTAL_NAME`` and ``ADMINPORTAL_SERVER_URL`` are removed in favor of the sites app. See upgrade instructions.
     * Added settings ``SCRIPTS`` and ``STYLES`` and removed ``STYLE_SHEET``
+    * The mailer textfield can now be configured using the new `MAILER_RICHTEXT_OPTIONS` setting
 
 
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -562,6 +562,18 @@ WHITELIST_EMAILS
     []
 
 
+MAILER_RICHTEXT_OPTIONS
+^^^^^^^^^^^^^^^^^^^^^^^
+  Configuration overrides of the tinyMCE editor of the mailer view.
+  See default config in ``static/juntagrico/js/initMailer.js``.
+
+  default value:
+
+  .. code-block:: python
+
+    {}
+
+
 GDPR
 ----
 

--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -156,6 +156,7 @@ class Config:
             'core': '/static/juntagrico/img/core.png'
         }
     )
+    mailer_richtext_options = _get_setting('MAILER_RICHTEXT_OPTIONS', {})
 
     # demo settings
     demouser = _get_setting('DEMO_USER')

--- a/juntagrico/static/juntagrico/js/initMailer.js
+++ b/juntagrico/static/juntagrico/js/initMailer.js
@@ -18,6 +18,7 @@ define([], function () {
         toolbar: "undo redo | bold italic | alignleft aligncenter alignright alignjustify | outdent indent | bullist numlist | link",
         convert_urls:true,
         remove_script_host:false,
+        ...JSON.parse(document.getElementById('mailer_richtext_options').textContent)
     });
     $("#sendmail").click(function () {
         var editor = tinyMCE.get('message');

--- a/juntagrico/templates/mail_sender.html
+++ b/juntagrico/templates/mail_sender.html
@@ -197,6 +197,8 @@
     </script>
     <script type="text/javascript" src="/static/juntagrico/external/tinymce/tinymce.min.js">
     </script>
+    {% config 'mailer_richtext_options' as c_mailer_richtext_options %}
+    {{ c_mailer_richtext_options|json_script:"mailer_richtext_options" }}
     <script type="text/javascript" src="/static/juntagrico/external/require.min.js" data-main="/static/juntagrico/js/initMailer.js">
     </script>
 {% endblock %}


### PR DESCRIPTION
Make the mailer tinymce editor field adjustable

Very specific example use case: We use the mailer templates to create the job list but then copy it from here to another newsletter tool. To simplify the workflow the font should be the correct one in the mailer editor already. For this I had to add `font-family` to the `valid_styles` options.