### PR TITLE
Email to all members with shares only with active shares

### DIFF
--- a/docs/1_4_release_notes.rst
+++ b/docs/1_4_release_notes.rst
@@ -4,6 +4,9 @@ Release Notes
 Dev
 ---
 
+Fixes
+^^^^^
+* Only include members with active shares, when mailing to all members with shares
 
 1.4.6
 -----

--- a/juntagrico/dao/memberdao.py
+++ b/juntagrico/dao/memberdao.py
@@ -79,7 +79,7 @@ class MemberDao:
     @staticmethod
     def members_with_shares():
         return Member.objects.filter(Q(share__isnull=False) & (
-                Q(share__termination_date__isnull=True) | Q(share__termination_date__gt=timezone.now())))
+            Q(share__termination_date__isnull=True) | Q(share__termination_date__gt=timezone.now())))
 
     @staticmethod
     def members_by_job(job):

--- a/juntagrico/dao/memberdao.py
+++ b/juntagrico/dao/memberdao.py
@@ -78,7 +78,8 @@ class MemberDao:
 
     @staticmethod
     def members_with_shares():
-        return Member.objects.filter(share__isnull=False)
+        return Member.objects.filter(Q(share__isnull=False) & (
+                Q(share__termination_date__isnull=True) | Q(share__termination_date__gt=timezone.now())))
 
     @staticmethod
     def members_by_job(job):
@@ -125,7 +126,7 @@ class MemberDao:
 
     @staticmethod
     def members_for_email_with_shares():
-        return Member.objects.filter(share__isnull=False).exclude(q_deactivated())
+        return MemberDao.members_with_shares().exclude(q_deactivated())
 
     @staticmethod
     def member_with_active_subscription_for_depot(depot):

--- a/test/test_comember.py
+++ b/test/test_comember.py
@@ -9,9 +9,9 @@ class CoMemberTests(JuntagricoTestCase):
 
     def setUp(self):
         super().setUp()
-        self.member5 = self.create_member('email5@email.org')
-        self.member5.iban = 'CH6189144414396247884'
-        self.member5.save()
+        self.co_member = self.create_member('co_member@email.org')
+        self.co_member.iban = 'CH6189144414396247884'
+        self.co_member.save()
         mail.outbox.clear()
 
     @staticmethod
@@ -54,17 +54,17 @@ class CoMemberTests(JuntagricoTestCase):
         self.assertNotEqual(self.member2.subscription_current, self.sub)
 
     def testAddExistingCoMember(self):
-        co_member_before = self.member5.__dict__
-        new_co_member_data = self.get_co_member_data(self.member5.email)
+        co_member_before = self.co_member.__dict__
+        new_co_member_data = self.get_co_member_data(self.co_member.email)
         self.assertPost(reverse('add-member', args=[self.sub.pk]), new_co_member_data, 302)
-        self.member5.refresh_from_db()
+        self.co_member.refresh_from_db()
         # member still exists and is unchanged
-        self.assertEqual(self.member5.id, co_member_before['id'])
-        self.assertEqual(self.member5.user_id, co_member_before['user_id'])
-        self.assertEqual(self.member5.iban, co_member_before['iban'])
-        self.assertEqual(self.member5.addr_street, co_member_before['addr_street'])
-        self.assertEqual(self.member5.first_name, co_member_before['first_name'])
+        self.assertEqual(self.co_member.id, co_member_before['id'])
+        self.assertEqual(self.co_member.user_id, co_member_before['user_id'])
+        self.assertEqual(self.co_member.iban, co_member_before['iban'])
+        self.assertEqual(self.co_member.addr_street, co_member_before['addr_street'])
+        self.assertEqual(self.co_member.first_name, co_member_before['first_name'])
         # no new shares should be created
-        self.assertEqual(Share.objects.filter(member=self.member5).count(), 0)
+        self.assertEqual(Share.objects.filter(member=self.co_member).count(), 0)
         # member now is part of subscription
-        self.assertEqual(self.member5.subscription_current, self.sub)
+        self.assertEqual(self.co_member.subscription_current, self.sub)

--- a/test/test_mailer.py
+++ b/test/test_mailer.py
@@ -1,3 +1,4 @@
+from django.core import mail
 from django.urls import reverse
 
 from test.util.test import JuntagricoTestCase
@@ -23,6 +24,14 @@ class MailerTests(JuntagricoTestCase):
             }
             self.assertGet(reverse('mail-send'), code=404)
             self.assertPost(reverse('mail-send'), post_data, code=302)
+
+    def testAllSharesMailSend(self):
+        post_data = {
+            'sender': 'test@mail.org',
+            'allshares': 'on'
+        }
+        self.assertPost(reverse('mail-send'), post_data, code=302)
+        self.assertListEqual(sorted(mail.outbox[0].bcc), ['email1@email.org', 'email4@email.org'])
 
     def testMailResult(self):
         self.assertGet(reverse('mail-result', args=[1]))

--- a/test/util/test.py
+++ b/test/util/test.py
@@ -56,6 +56,7 @@ class JuntagricoTestCase(TestCase):
         self.member2 = self.create_member('email2@email.org')
         self.member3 = self.create_member('email3@email.org')
         self.member4 = self.create_member('email4@email.org')
+        self.member5 = self.create_member('email5@email.org')
         self.member.user.user_permissions.add(
             Permission.objects.get(codename='is_depot_admin'))
         self.member.user.user_permissions.add(

--- a/test/util/test.py
+++ b/test/util/test.py
@@ -140,6 +140,14 @@ class JuntagricoTestCase(TestCase):
         self.share = Share.objects.create(**self.share_data)
         self.share_data4 = self.get_share_data(self.member4)
         self.share4 = Share.objects.create(**self.share_data4)
+        # create cancelled but not paid back share
+        self.share_data5 = self.get_share_data(self.member5)
+        self.share_data5.update({
+            'booking_date': '2017-12-27',
+            'cancelled_date': '2017-12-27',
+            'termination_date': '2017-12-27',
+        })
+        self.share5 = Share.objects.create(**self.share_data5)
 
     def set_up_area(self):
         """


### PR DESCRIPTION
In the mailer, when selecting "send to all members with shares" the expected result is, that it is only sent to members that hold shares that have not reached their termination date yet, i.e., members with voting rights.