### PR TITLE
#427 custom page-wide scripts and styles

### DIFF
--- a/docs/1_5_release_notes.rst
+++ b/docs/1_5_release_notes.rst
@@ -10,6 +10,7 @@ Upgrade Instructions
   using the values from your ``ADMINPORTAL_NAME`` and ``ADMINPORTAL_SERVER_URL`` settings.
     * Remove these settings.
     * Add ``'django.contrib.sites.middleware.CurrentSiteMiddleware'`` to the ``MIDDLEWARE`` setting.
+* Replace the ``STYLE_SHEET`` setting with ``STYLES = {'static': ['your.css']}``
 
 Fixes
 ^^^^^

--- a/docs/1_5_release_notes.rst
+++ b/docs/1_5_release_notes.rst
@@ -23,6 +23,7 @@ Features & Improvements
 
 * Developer Features:
     * ``ADMINPORTAL_NAME`` and ``ADMINPORTAL_SERVER_URL`` are removed in favor of the sites app. See upgrade instructions.
+    * Added settings ``SCRIPTS`` and ``STYLES`` and removed ``STYLE_SHEET``
 
 
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -413,17 +413,37 @@ SUB_OVERVIEW_FORMAT
      'format': '{product}:{size}:{type}={amount}'
     }
 
-STYLE_SHEET
-^^^^^^^^^^^
-  If you want to use a custom design this specifies the path for your css
-
-  Type: String
+STYLES
+^^^^^^
+  Define styles to be included on all pages.
+  If the template key is set, the specified template will be loaded in the header of the page.
+  In the static key a list of css files can be defined to be included.
+  If both keys are defined the template is included before the static css files.
 
   default value
 
   .. code-block:: python
 
-    "/static/juntagrico/css/personal.css"
+    {
+        'template': '',
+        'static': []
+    }
+
+SCRIPTS
+^^^^^^^
+  Define scripts to be included on all pages.
+  If the template key is set, the specified template will be loaded in the scripts part of the page.
+  In the static key a list of javascript files can be defined to be included.
+  If both keys are defined the template is included before the static javascript files.
+
+  default value
+
+  .. code-block:: python
+
+    {
+        'template': '',
+        'static': []
+    }
 
 FAVICON
 ^^^^^^^

--- a/docs/theming.rst
+++ b/docs/theming.rst
@@ -5,7 +5,7 @@ Custom CSS
 ----------
 
 1. Add your custom CSS file e.g. ``{app}/static/css/{app}.css``
-2. Adjust the ``STYLE_SHEET`` setting to point to that file
+2. Adjust the ``STYLES`` setting to point to that file: ``STYLES = {'static': ['css/{app}.css']}``
 
 Note that the setting is specified without the ``{app}`` folder,
 as django will collect all static files into a single location.

--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -138,7 +138,8 @@ class Config:
             'm_canceled': 'mails/admin/member_canceled.txt',
         }
     )
-    style_sheet = _get_setting('STYLE_SHEET', '/static/juntagrico/css/personal.css')
+    styles = _get_setting_with_key('STYLES', {'template': '', 'static': []})
+    scripts = _get_setting_with_key('SCRIPTS', {'template': '', 'static': []})
     favicon = _get_setting('FAVICON', '/static/juntagrico/img/favicon.ico')
     bootstrap = _get_setting('BOOTSTRAP', '/static/juntagrico/external/bootstrap-4.3.1/css/bootstrap.min.css')
     images = _get_setting_with_key(

--- a/juntagrico/templates/base.html
+++ b/juntagrico/templates/base.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load static %}
 {% load juntagrico.common %}
 {% load juntagrico.config %}
 {% load juntagrico.menu %}
@@ -26,7 +27,14 @@
         {% endblock %}
         <link href="/static/juntagrico/css/juntagrico.css" rel="stylesheet"/>
         <link href="/static/juntagrico/css/slider.css" rel="stylesheet"/>
-        <link href="{% config "style_sheet" %}" rel="stylesheet"/>
+        {% styles "template" as styles_template %}
+        {% if styles_template %}
+            {% include styles_template %}
+        {% endif %}
+        {% styles "static" as static_styles %}
+        {% for static_style in static_styles %}
+            <link href="{% static static_style %}" rel="stylesheet"/>
+        {% endfor %}
     </head>
     <body id="{{ request|view_name }}" class="{% block body_extra_classes %}{% endblock %}">
         <div class="page-container container">
@@ -153,5 +161,13 @@
         {% block scripts %}
             {# no scripts by default #}
         {% endblock %}
+        {% scripts "template" as scripts_template %}
+        {% if scripts_template %}
+            {% include scripts_template %}
+        {% endif %}
+        {% scripts "static" as static_scripts %}
+        {% for static_script in static_scripts %}
+            <script type="text/javascript" src="{% static static_script %}"></script>
+        {% endfor %}
     </body>
 </html>

--- a/juntagrico/templatetags/juntagrico/config.py
+++ b/juntagrico/templatetags/juntagrico/config.py
@@ -38,3 +38,13 @@ def get_config_classes():
     configs = [Config]
     configs.extend(addons_config.get_config_classes())
     return configs
+
+
+@register.simple_tag
+def scripts(key):
+    return Config.scripts(key)
+
+
+@register.simple_tag
+def styles(key):
+    return Config.styles(key)


### PR DESCRIPTION
closes #427

I implemented both option: template and a list of static files.
The templates approach is more flexible, while the static files are easier to specify (no extra template file must be created).
I'm also thinking of the use case, where extensions give instructions to add a certain style or script to the settings.
