### PR TITLE
cancelled subscriptions are still active

### DIFF
--- a/docs/1_4_release_notes.rst
+++ b/docs/1_4_release_notes.rst
@@ -4,6 +4,9 @@ Release Notes
 Dev
 ---
 
+Fixes
+^^^^^
+* Fix: Cancelled, but still active subscriptions are now shown in the member list
 
 1.4.6
 -----

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -152,7 +152,7 @@ class Member(JuntagricoBaseModel):
             sub_membership.leave_date = None
             sub_membership.save()
         else:
-            join_date = timezone.now().date() if subscription.active else None
+            join_date = None if subscription.waiting else timezone.now().date()
             SubscriptionMembership.objects.create(member=self, subscription=subscription, join_date=join_date)
 
     def leave_subscription(self, subscription, changedate=None):

--- a/juntagrico/templates/members.html
+++ b/juntagrico/templates/members.html
@@ -92,7 +92,7 @@
                             {% endfor %}
                         </td>
                         <td>
-                            {% if member.subscription_current != None and member.subscription_current.active %}
+                            {% if member.subscription_current != None %}
                                 {{ member.subscription_current.depot.name }}
                             {% else %}
                                 Kein {% vocabulary "depot" %}
@@ -108,7 +108,7 @@
                             {{ member.mobile_phone }}
                         </td>
                         <td>
-                            {% if member.subscription_current != None and member.subscription_current.active %}
+                            {% if member.subscription_current != None %}
                                 {{ member.subscription_current.size }}
                             {% else %}
                                 Kein {% vocabulary "subscription" %}


### PR DESCRIPTION
Issue was, that cancelled subscription would not show in the member list as their status was "cancelled" not "active".
I removed the condition, because, `subscription_current` only includes subscriptions that the member joined but did not leave yet, which by consistency rules must be an active (or cancelled) subscription.

A similar issue on the `join_subscription` would cause the co-member to not fully join a subscription if it was already cancelled (but leave the co-member in a waiting state). The case of trying to join an inactive subscription will, as before, raise a validation error in the consistency checks.

there is no other use of the `active` flag. That name is misleading and we might want to change it to `active_and_not_cancelled`, or remove it completely