### PR TITLE
poc for unified job admin

### DIFF
--- a/juntagrico/admin.py
+++ b/juntagrico/admin.py
@@ -5,7 +5,7 @@ from juntagrico.admins.area_admin import AreaAdmin
 from juntagrico.admins.assignment_admin import AssignmentAdmin
 from juntagrico.admins.delivery_admin import DeliveryAdmin
 from juntagrico.admins.depot_admin import DepotAdmin
-from juntagrico.admins.job_admin import JobAdmin
+from juntagrico.admins.job_admin import JobAdmin, AbstractJobAdmin
 from juntagrico.admins.job_type_admin import JobTypeAdmin
 from juntagrico.admins.list_message_admin import ListMessageAdmin
 from juntagrico.admins.location_admin import LocationAdmin
@@ -20,7 +20,8 @@ from juntagrico.entity.billing import BillingPeriod
 from juntagrico.entity.delivery import Delivery
 from juntagrico.entity.location import Location
 from juntagrico.entity.depot import Depot
-from juntagrico.entity.jobs import Assignment, ActivityArea, JobExtra, JobExtraType, JobType, RecuringJob, OneTimeJob
+from juntagrico.entity.jobs import Assignment, ActivityArea, JobExtra, JobExtraType, JobType, RecuringJob, OneTimeJob, \
+    Job
 from juntagrico.entity.listmessage import ListMessage
 from juntagrico.entity.mailing import MailTemplate
 from juntagrico.entity.member import Member, SubscriptionMembership
@@ -47,6 +48,7 @@ admin.site.register(Delivery, DeliveryAdmin)
 admin.site.register(JobExtra, BaseAdmin)
 admin.site.register(JobExtraType, BaseAdmin)
 admin.site.register(JobType, JobTypeAdmin)
+admin.site.register(Job, AbstractJobAdmin)
 admin.site.register(RecuringJob, JobAdmin)
 admin.site.register(OneTimeJob, OneTimeJobAdmin)
 admin.site.register(ListMessage, ListMessageAdmin)

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -1,8 +1,11 @@
+from django.core.exceptions import PermissionDenied
+from django.db.models import Q
 from django.urls import re_path
 from django.contrib import admin
 from django.http import HttpResponseRedirect
 from django.utils.translation import gettext as _
-from polymorphic.admin import PolymorphicInlineSupportMixin
+from polymorphic.admin import PolymorphicInlineSupportMixin, PolymorphicParentModelAdmin, PolymorphicChildModelAdmin, \
+    PolymorphicChildModelFilter
 
 from juntagrico.admins import RichTextAdmin
 from juntagrico.admins.admin_decorators import single_element_action
@@ -10,16 +13,67 @@ from juntagrico.admins.filters import FutureDateTimeFilter
 from juntagrico.admins.forms.job_copy_form import JobCopyForm
 from juntagrico.admins.inlines.assignment_inline import AssignmentInline
 from juntagrico.admins.inlines.contact_inline import ContactInline
+from juntagrico.dao.activityareadao import ActivityAreaDao
 from juntagrico.dao.jobtypedao import JobTypeDao
-from juntagrico.entity.jobs import RecuringJob, JobType
+from juntagrico.entity.jobs import RecuringJob, JobType, OneTimeJob
 from juntagrico.util.admin import formfield_for_coordinator, queryset_for_coordinator
 
 
-class JobAdmin(PolymorphicInlineSupportMixin, RichTextAdmin):
+class ActivityAreaFilter(admin.SimpleListFilter):
+    title = _('Tätigkeitsbereich')
+    parameter_name = "area"
+
+    def lookups(self, request, model_admin):
+        qs = ActivityAreaDao.all_visible_areas_ordered()
+        if request.user.has_perm('juntagrico.is_area_admin') and (
+                not (request.user.is_superuser or request.user.has_perm('juntagrico.is_operations_group'))):
+            qs = qs.filter(coordinator=request.user.member)
+        return qs.values_list('id', 'name')
+
+    def queryset(self, request, queryset):
+        try:
+            value = int(self.value())
+        except TypeError:
+            value = None
+        if value:
+            # check permission
+            for choice_value in self.lookup_choices:
+                if choice_value[0] == value:
+                    return queryset.filter(
+                        Q(RecuringJob___type__activityarea=value) | Q(OneTimeJob___activityarea=value))
+            raise PermissionDenied(_('Kein Zugriff auf Tätigkeitsbereich "{}".'.format(value)))
+        return queryset
+
+
+# Known issues: Children are visible in sidebar https://github.com/django-polymorphic/django-polymorphic/issues/497
+class AbstractJobAdmin(PolymorphicParentModelAdmin):
+    """ The parent model admin """
+    child_models = (RecuringJob, OneTimeJob)
+    polymorphic_list = True
+    list_display = ['__str__', 'type', 'time', 'slots', 'free_slots']
+    list_filter = (PolymorphicChildModelFilter, ActivityAreaFilter, ('time', FutureDateTimeFilter))
+    search_fields = ['RecuringJob___type__name', 'RecuringJob___type__activityarea__name',
+                     'OneTimeJob___activityarea__name', 'OneTimeJob___name', 'time']
+    # TODO: combine actions of child classes
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.has_perm('juntagrico.is_area_admin') and (
+                not (request.user.is_superuser or request.user.has_perm('juntagrico.is_operations_group'))):
+            member = request.user.member
+            return qs.filter(
+                Q(RecuringJob___type__activityarea__coordinator=member) | Q(
+                    OneTimeJob___activityarea__coordinator=member))
+        return qs
+
+
+class JobAdmin(PolymorphicInlineSupportMixin, RichTextAdmin, PolymorphicChildModelAdmin):
+    base_model = RecuringJob
     list_display = ['__str__', 'type', 'time', 'slots', 'free_slots']
     list_filter = ('type__activityarea', ('time', FutureDateTimeFilter))
     actions = ['copy_job', 'mass_copy_job']
     search_fields = ['type__name', 'type__activityarea__name', 'time']
+
     exclude = ['reminder_sent']
     inlines = [ContactInline, AssignmentInline]
     readonly_fields = ['free_slots']

--- a/juntagrico/admins/one_time_job_admin.py
+++ b/juntagrico/admins/one_time_job_admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.db.models import Q
 from django.utils.translation import gettext as _
-from polymorphic.admin import PolymorphicInlineSupportMixin
+from polymorphic.admin import PolymorphicInlineSupportMixin, PolymorphicChildModelAdmin
 
 from juntagrico.admins import RichTextAdmin
 from juntagrico.admins.filters import FutureDateTimeFilter
@@ -10,13 +10,14 @@ from juntagrico.admins.inlines.contact_inline import ContactInline
 from juntagrico.admins.inlines.job_extra_inline import JobExtraInline
 from juntagrico.dao.activityareadao import ActivityAreaDao
 from juntagrico.dao.assignmentdao import AssignmentDao
-from juntagrico.entity.jobs import JobType, RecuringJob
+from juntagrico.entity.jobs import JobType, RecuringJob, OneTimeJob
 from juntagrico.entity.location import Location
 from juntagrico.util.admin import formfield_for_coordinator, queryset_for_coordinator
 from juntagrico.util.models import attribute_copy
 
 
-class OneTimeJobAdmin(PolymorphicInlineSupportMixin, RichTextAdmin):
+class OneTimeJobAdmin(PolymorphicInlineSupportMixin, RichTextAdmin, PolymorphicChildModelAdmin):
+    base_model = OneTimeJob
     list_display = ['__str__', 'time', 'slots', 'free_slots']
     list_filter = ('activityarea', ('time', FutureDateTimeFilter))
     actions = ['transform_job']


### PR DESCRIPTION
This is a draft for a job admin that combines recurring and one time jobs using the polymorphic admin integration: https://django-polymorphic.readthedocs.io/en/stable/admin.html

Advantages of having a single admin interface are:
* Overview: Jobs can all be searched in one place, no need to jump between admins
* Discoverability: Users will be confronted with the choice between recuring job and one time job. No way to miss it.
* Maintainability: Using a single list reduces the risk of forgetting to apply a change to the one as well.

# TODO

- [ ] Combine actions. If a job is selected that is not compatible with the action, the action will say so. Also the action name should hint which types work with it.
- [ ] Rename `JobAdmin` -> `RecurringJobAdmin` and give them reasonable verbose names
