### PR TITLE
fix deletion of jobs

### DIFF
--- a/docs/1_5_release_notes.rst
+++ b/docs/1_5_release_notes.rst
@@ -11,7 +11,7 @@ Features & Improvements
 Fixes
 ^^^^^
 * upgrade django to fix bug that affects saving subscriptions in admin: https://code.djangoproject.com/ticket/33547
-
+* fix page error when trying to delete job with assignment
 
 1.5.2
 -----

--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -355,7 +355,7 @@ class Assignment(JuntagricoBaseModel):
         instance.core_cache = instance.is_core()
 
     def can_modify(self, request):
-        return self.job.can_modify(request)
+        return self.job.get_real_instance().can_modify(request)
 
     class Meta:
         verbose_name = Config.vocabulary('assignment')

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -32,6 +32,10 @@ class AdminTests(JuntagricoTestCase):
         selected_items = [self.job1.pk, self.job2.pk]
         self.assertPost(url, data={'action': 'mass_copy_job', '_selected_action': selected_items}, member=self.admin,
                         code=302)
+        # delete job without assignment
+        self.assertGet(reverse('admin:juntagrico_recuringjob_delete', args=(self.job1.pk,)), member=self.admin)
+        # delete job with assignment (will show a page, that assignments must be deleted first)
+        self.assertGet(reverse('admin:juntagrico_recuringjob_delete', args=(self.job2.pk,)), member=self.admin)
 
     def testDeliveryAdmin(self):
         self.assertGet(reverse('admin:juntagrico_delivery_add'), member=self.admin)


### PR DESCRIPTION
fixes #532

for some reason we get an abstract `Job` instance in `can_modify` in some cases (e.g. when deleting a job), but not in others (e.g. when editing an assignment).
Doing an upcast here if needed.