### PR TITLE
Job status imgs

### DIFF
--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -171,4 +171,4 @@ class Config:
     demopwd = _get_setting('DEMO_PWD')
 
     # job status display option
-    use_job_status_images = _get_setting('USE_JOB_STATUS_IMAGES', True)
+    use_job_status_images = _get_setting('USE_JOB_STATUS_IMAGES', False)

--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -169,3 +169,6 @@ class Config:
     # demo settings
     demouser = _get_setting('DEMO_USER')
     demopwd = _get_setting('DEMO_PWD')
+
+    # job status display option
+    use_job_status_images = _get_setting('USE_JOB_STATUS_IMAGES', False)

--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -171,4 +171,4 @@ class Config:
     demopwd = _get_setting('DEMO_PWD')
 
     # job status display option
-    use_job_status_images = _get_setting('USE_JOB_STATUS_IMAGES', False)
+    use_job_status_images = _get_setting('USE_JOB_STATUS_IMAGES', True)

--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -1,3 +1,5 @@
+import math
+
 from django.contrib import admin
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.validators import MinValueValidator
@@ -208,6 +210,12 @@ class Job(JuntagricoBasePoly):
         if self.slots < 1:
             return 100
         return assignments.count() * 100 / self.slots
+
+    def get_status_img(self):
+        percent = self.status_percentage()
+        status_number = min(100, int(25 * math.floor(float(percent) / 25)))
+        result = 'status_' + str(status_number)
+        return result
 
     def is_core(self):
         return self.type.activityarea.core

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -3,6 +3,7 @@
 {% load juntagrico.config %}
 {% show_core as b_show_core %}
 {% show_job_extras as b_show_job_extras %}
+{% use_job_status_images as b_use_job_status_images %}
 <table id="filter-table" class="list table" style="width: 100%">
     <thead>
         <tr>
@@ -79,7 +80,7 @@
                         {% endif %}
                     </td>
                 {% endif %}
-                {% if not use_job_status_images %}
+                {% if not b_use_job_status_images %}
                 <td class="
                     {% if job.status_percentage < 25 %}
                         text-danger
@@ -91,7 +92,7 @@
                     {% if job.free_slots > -1 %}
                     {{ job.occupied_slots }} / {{ job.slots }}
                     {% endif %}
-                    Use job status images: {{ use_job_status_images }}
+                    Use job status images: {{ b_use_job_status_images }}
                 </td>
                 {% else %}
                 <td>

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -91,7 +91,7 @@
                     {% if job.free_slots > -1 %}
                     {{ job.occupied_slots }} / {{ job.slots }}
                     {% endif %}
-                    {{ use_job_status_images }}
+                    Use job status images: {{ use_job_status_images }}
                 </td>
                 {% else %}
                 <td>

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -8,7 +8,7 @@
         <tr>
             <th class="job-description"></th>
             <th class="align-top table-search job-date">
-                {% trans "Datum" %}
+                {% trans "Datum" %} Tudeluu
             </th>
             <th class="align-top table-search job-name">
                 {% trans "Job" %}

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -1,10 +1,9 @@
 {% load i18n %}
 {% load juntagrico.common %}
-
+{% load juntagrico.config %}
 {% show_core as b_show_core %}
 {% show_job_extras as b_show_job_extras %}
-{% vocabulary "member_type" as v_member_type %}
-{% use_job_status_images as b_use_job_status_images %}
+{% config "use_job_status_images" as use_job_status_images %}
 <table id="filter-table" class="list table" style="width: 100%">
     <thead>
         <tr>
@@ -81,7 +80,7 @@
                         {% endif %}
                     </td>
                 {% endif %}
-                {% if not b_use_job_status_images %}
+                {% if not use_job_status_images %}
                 <td class="
                     {% if job.status_percentage < 25 %}
                         text-danger
@@ -93,7 +92,7 @@
                     {% if job.free_slots > -1 %}
                     {{ job.occupied_slots }} / {{ job.slots }}
                     {% endif %}
-                    Use job status images: {{ b_use_job_status_images }}
+                    
                 </td>
                 {% else %}
                 <td>

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -3,6 +3,7 @@
 {% load juntagrico.config %}
 {% show_core as b_show_core %}
 {% show_job_extras as b_show_job_extras %}
+{% vocabulary "member_type" as v_member_type %}
 {% use_job_status_images as b_use_job_status_images %}
 <table id="filter-table" class="list table" style="width: 100%">
     <thead>

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -8,7 +8,7 @@
         <tr>
             <th class="job-description"></th>
             <th class="align-top table-search job-date">
-                {% trans "Datum Tudeluu" %}
+                {% trans "Datum" %} "Tudeluu"
             </th>
             <th class="align-top table-search job-name">
                 {% trans "Job" %}

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load juntagrico.common %}
-{% load juntagrico.config %}
+
 {% show_core as b_show_core %}
 {% show_job_extras as b_show_job_extras %}
 {% vocabulary "member_type" as v_member_type %}

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -8,7 +8,7 @@
         <tr>
             <th class="job-description"></th>
             <th class="align-top table-search job-date">
-                {% trans "Datum" %}
+                {% trans "Datum Tudeluu" %}
             </th>
             <th class="align-top table-search job-name">
                 {% trans "Job" %}

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -8,7 +8,7 @@
         <tr>
             <th class="job-description"></th>
             <th class="align-top table-search job-date">
-                {% trans "Datum" %} Tudeluu
+                {% trans "Datum" %}
             </th>
             <th class="align-top table-search job-name">
                 {% trans "Job" %}
@@ -79,7 +79,8 @@
                         {% endif %}
                     </td>
                 {% endif %}
-                <!-- <td class="
+                {% if not use_job_status_images %}
+                <td class="
                     {% if job.status_percentage < 25 %}
                         text-danger
                     {% elif job.status_percentage < 100%}
@@ -90,12 +91,14 @@
                     {% if job.free_slots > -1 %}
                     {{ job.occupied_slots }} / {{ job.slots }}
                     {% endif %}
-                </td> -->
+                </td>
+                {% else %}
                 <td>
                     {% if job.free_slots > -1 %}
                         <img alt="{{ job.occupied_slots }} / {{ job.slots }}" src="{% images job.get_status_img %}"/>
                     {% endif %}
                 </td>
+                {% endif %}
                 {% if show_free_slot_filter %}
                     <td>
                         {{ job.free_slots }}

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -8,7 +8,7 @@
         <tr>
             <th class="job-description"></th>
             <th class="align-top table-search job-date">
-                {% trans "Datum" %} "Tudeluu"
+                {% trans "Datum" %}
             </th>
             <th class="align-top table-search job-name">
                 {% trans "Job" %}
@@ -79,7 +79,7 @@
                         {% endif %}
                     </td>
                 {% endif %}
-                <td class="
+                <!-- <td class="
                     {% if job.status_percentage < 25 %}
                         text-danger
                     {% elif job.status_percentage < 100%}
@@ -89,6 +89,11 @@
                 ">
                     {% if job.free_slots > -1 %}
                     {{ job.occupied_slots }} / {{ job.slots }}
+                    {% endif %}
+                </td> -->
+                <td>
+                    {% if job.free_slots > -1 %}
+                        <img alt="{{ job.occupied_slots }} / {{ job.slots }}" src="{% images job.get_status_img %}"/>
                     {% endif %}
                 </td>
                 {% if show_free_slot_filter %}

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -91,6 +91,7 @@
                     {% if job.free_slots > -1 %}
                     {{ job.occupied_slots }} / {{ job.slots }}
                     {% endif %}
+                    {{ use_job_status_images }}
                 </td>
                 {% else %}
                 <td>


### PR DESCRIPTION
Implemented option to change the display of the job status back to the status images by setting the new setting: USE_JOB_STATUS_IMAGES to true.