### PR TITLE
Fix required assignments (backport for 1.4.x)

### DIFF
--- a/juntagrico/entity/subs.py
+++ b/juntagrico/entity/subs.py
@@ -13,8 +13,7 @@ from juntagrico.entity.member import q_left_subscription, q_joined_subscription
 from juntagrico.lifecycle.sub import check_sub_consistency
 from juntagrico.lifecycle.subpart import check_sub_part_consistency
 from juntagrico.util.models import q_activated, q_cancelled, q_deactivated, q_deactivation_planned, q_isactive
-from juntagrico.util.temporal import start_of_next_business_year, start_of_business_year, \
-    calculate_remaining_days_percentage
+from juntagrico.util.temporal import start_of_next_business_year, start_of_business_year, end_of_business_year
 
 
 class Subscription(Billable, SimpleStateModel):
@@ -80,6 +79,11 @@ class Subscription(Billable, SimpleStateModel):
         return self.parts.filter(~q_deactivated())
 
     @property
+    def parts_in_business_year(self):
+        return self.parts.filter(Q(activation_date__isnull=False, activation_date__lte=end_of_business_year()) &
+                                 ~Q(deactivation_date__isnull=False, deactivation_date__lt=start_of_business_year()))
+
+    @property
     def part_change_date(self):
         order_dates = list(self.future_parts.values_list('creation_date', flat=True).order_by('creation_date'))
         cancel_dates = list(self.active_parts.values_list('cancellation_date', flat=True).order_by('cancellation_date'))
@@ -121,21 +125,14 @@ class Subscription(Billable, SimpleStateModel):
 
     @property
     def required_assignments(self):
-        result = 0
-        for part in self.active_parts.all():
-            result += part.type.required_assignments
-        if self.activation_date is not None and self.activation_date > start_of_business_year():
-            result = round(result * calculate_remaining_days_percentage(self.activation_date))
-        return result
+        return self.get_required_assignments()
 
     @property
     def required_core_assignments(self):
-        result = 0
-        for part in self.active_parts.all():
-            result += part.type.required_core_assignments
-        if self.activation_date is not None and self.activation_date > start_of_business_year():
-            result = round(result * calculate_remaining_days_percentage(self.activation_date))
-        return result
+        return self.get_required_assignments(True)
+
+    def get_required_assignments(self, core=False):
+        return round(sum([part.get_required_assignments(core) for part in self.parts_in_business_year.select_related('type')]))
 
     @property
     def price(self):
@@ -273,6 +270,23 @@ class SubscriptionPart(JuntagricoBaseModel, SimpleStateModel):
     @property
     def is_extra(self):
         return self.type.size.product.is_extra
+
+    def get_required_assignments(self, core=False):
+        if not self.activation_date:
+            return 0
+        nominal_required = self.type.required_core_assignments if core else self.type.required_assignments
+        # on trial subs no discount applies
+        if self.type.trial_days:
+            return nominal_required
+        # since when part is active in current business year
+        start_business = start_of_business_year()
+        start = max(self.activation_date, start_business)
+        # when (if at all) part will be inactive in current business year
+        end_business = end = end_of_business_year()
+        if self.deactivation_date:
+            end = min(self.deactivation_date, end_business)
+        # percentage of business year, where part is active. Do not round here.
+        return nominal_required * (end - start) / (end_business - start_business)
 
     def clean(self):
         check_sub_part_consistency(self)

--- a/juntagrico/util/temporal.py
+++ b/juntagrico/util/temporal.py
@@ -2,6 +2,7 @@ import calendar
 import datetime
 from datetime import timedelta
 
+from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
@@ -91,14 +92,16 @@ def next_membership_end_date():
     """
     :return: end date of membership when canceling now
     """
+    endmonth = Config.membership_end_month()
+    noticemonths = (12 + endmonth - Config.business_year_cancelation_month()) % 12
     now = timezone.now().date()
-    month = Config.membership_end_month()
-    if now <= cancelation_date():
-        offset = end_of_business_year()
+    nowplusnotice = now + relativedelta(months=noticemonths)
+    if nowplusnotice.month <= endmonth:
+        endyear = nowplusnotice.year
     else:
-        offset = end_of_next_business_year()
-    day = days_in_month(offset.year, month)
-    return datetime.date(offset.year, month, day)
+        endyear = nowplusnotice.year + 1
+    day = days_in_month(endyear, endmonth)
+    return datetime.date(endyear, endmonth, day)
 
 
 def calculate_next(day, month):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ icalendar==4.0.9
 schwifty==2021.10.2
 xhtml2pdf==0.2.4 # rq.filter: !=0.2.5
 XlsxWriter==3.0.2
+python-dateutil==2.8.2

--- a/test/test_assignments.py
+++ b/test/test_assignments.py
@@ -1,0 +1,62 @@
+from datetime import date
+
+from django.utils import timezone
+
+from juntagrico.entity.subs import SubscriptionPart, Subscription
+from juntagrico.entity.subtypes import SubscriptionType
+from test.util.test import JuntagricoTestCase
+
+
+class AssignmentTests(JuntagricoTestCase):
+
+    def setUp(self):
+        super().setUp()
+        sub_type_data = {
+            'name': 'sub_trial_type',
+            'long_name': 'sub_type_long_name',
+            'size': self.sub_size,
+            'shares': 2,
+            'visible': True,
+            'required_assignments': 10,
+            'required_core_assignments': 3,
+            'price': 1000,
+            'description': 'sub_type_desc'}
+        self.sub_trial_type = SubscriptionType.objects.create(trial_days=30, **sub_type_data)
+
+        year = timezone.now().year
+        activation_date = date(day=1, month=7, year=year)
+        self.sub2.activation_date = activation_date
+        SubscriptionPart.objects.create(subscription=self.sub2, type=self.sub_type, activation_date=activation_date)
+        activation_date = date(day=1, month=1, year=year)
+        deactivation_date = date(day=30, month=6, year=year)
+        sub_data = {
+            'depot': self.depot,
+            'future_depot': None,
+            'creation_date': '2017-03-27',
+            'start_date': '2018-01-01'
+        }
+        dates = {
+            'activation_date': activation_date,
+            'cancellation_date': activation_date,
+            'deactivation_date': deactivation_date,
+        }
+        sub_data3 = {**sub_data, **dates}
+        # sub in first half of the year
+        self.sub3 = Subscription.objects.create(**sub_data3)
+        SubscriptionPart.objects.create(subscription=self.sub3, type=self.sub_type, **dates)
+        # trial sub
+        self.sub4 = Subscription.objects.create(**sub_data3)
+        SubscriptionPart.objects.create(subscription=self.sub4, type=self.sub_trial_type, **dates)
+        # ordered, not activated sub
+        self.sub5 = Subscription.objects.create(**sub_data)
+        SubscriptionPart.objects.create(subscription=self.sub5, type=self.sub_type)
+
+    def testRequiredAssignments(self):
+        self.assertEqual(self.sub2.required_assignments, 5)
+        self.assertEqual(self.sub2.required_core_assignments, 2)
+        self.assertEqual(self.sub3.required_assignments, 5)
+        self.assertEqual(self.sub3.required_core_assignments, 1)  # first 6 months or the year are a bit shorter
+        self.assertEqual(self.sub4.required_assignments, 10)
+        self.assertEqual(self.sub4.required_core_assignments, 3)
+        self.assertEqual(self.sub5.required_assignments, 0)
+        self.assertEqual(self.sub5.required_core_assignments, 0)

--- a/test/util/test.py
+++ b/test/util/test.py
@@ -260,6 +260,7 @@ class JuntagricoTestCase(TestCase):
             'shares': 1,
             'visible': True,
             'required_assignments': 10,
+            'required_core_assignments': 3,
             'price': 1000,
             'description': 'sub_type_desc'}
         self.sub_type = SubscriptionType.objects.create(**sub_type_data)
@@ -270,6 +271,7 @@ class JuntagricoTestCase(TestCase):
             'shares': 2,
             'visible': True,
             'required_assignments': 10,
+            'required_core_assignments': 3,
             'price': 1000,
             'description': 'sub_type_desc'}
         self.sub_type2 = SubscriptionType.objects.create(**sub_type_data)
@@ -301,7 +303,7 @@ class JuntagricoTestCase(TestCase):
         self.member2.join_subscription(self.sub2)
         self.sub2.primary_member = self.member2
         self.sub2.save()
-        SubscriptionPart.objects.create(subscription=self.sub, type=self.sub_type)
+        SubscriptionPart.objects.create(subscription=self.sub, type=self.sub_type, activation_date=timezone.now().date())
 
     def set_up_extra_sub_types(self):
         """


### PR DESCRIPTION
this fixes the critical part of #442 and applies a minimal fix based on #536.

Requires assignments of under-year parts are calculated correctly.
For trial parts it is assumed, that no discount is applied, i.e. the required assignments set in the trial sub are always the same.