### PR TITLE
fix admin error on adding job without time without past jobs edit per…

### DIFF
--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -25,12 +25,11 @@ def can_edit_past_jobs(request):
 
 
 class OnlyFutureJobAdminForm(forms.ModelForm):
-    def clean(self):
-        cleaned_data = super().clean()
-        if cleaned_data['time'] <= timezone.now():
-            raise ValidationError(
-                _('Neue Jobs können nicht in der Vergangenheit liegen.'))
-        return cleaned_data
+    def clean_time(self):
+        time = self.cleaned_data['time']
+        if time <= timezone.now():
+            raise ValidationError(_('Neue Jobs können nicht in der Vergangenheit liegen.'))
+        return time
 
 
 class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTextAdmin):

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from django.utils import timezone
 
 from juntagrico.entity.jobs import Assignment
 from test.util.test import JuntagricoTestCase
@@ -48,6 +49,27 @@ class AdminTests(JuntagricoTestCase):
         self.assertGet(reverse('admin:juntagrico_recuringjob_delete', args=(self.job2.pk,)), member=self.admin)
 
     def testPastJobAdmin(self):
+        add_url = reverse('admin:juntagrico_recuringjob_add')
+        self.assertGet(add_url, member=self.area_admin)
+        # post shows error if no time is passed
+        self.assertPost(add_url,
+                        data={'type': self.job1.type.pk, 'slots': 1, 'multiplier': 1,
+                              'assignment_set-TOTAL_FORMS': 0, 'assignment_set-INITIAL_FORMS': 0},
+                        member=self.area_admin)
+        # post shows error if past time is passed
+        past = timezone.now() - timezone.timedelta(days=2)
+        self.assertPost(add_url,
+                        data={'type': self.job1.type.pk, 'slots': 1, 'multiplier': 1,
+                              'time_0': past.date(), 'time_1': past.time(),
+                              'assignment_set-TOTAL_FORMS': 0, 'assignment_set-INITIAL_FORMS': 0},
+                        member=self.area_admin)
+        # post works for future time
+        future = timezone.now() + timezone.timedelta(days=2)
+        self.assertPost(add_url,
+                        data={'type': self.job1.type.pk, 'slots': 1, 'multiplier': 1,
+                              'time_0': future.date(), 'time_1': future.time(),
+                              'assignment_set-TOTAL_FORMS': 0, 'assignment_set-INITIAL_FORMS': 0},
+                        member=self.area_admin, code=302)
         self.assertGet(reverse('admin:juntagrico_recuringjob_change', args=(self.past_job.pk,)), member=self.admin)
         self.assertGet(reverse('admin:juntagrico_recuringjob_change', args=(self.past_job.pk,)), member=self.area_admin)
         self.assertGet(reverse('admin:juntagrico_onetimejob_change', args=(self.past_one_time_job.pk,)), member=self.admin)

--- a/test/util/test.py
+++ b/test/util/test.py
@@ -126,6 +126,8 @@ class JuntagricoTestCase(TestCase):
         self.area_admin.user.user_permissions.add(
             Permission.objects.get(codename='change_recuringjob'))
         self.area_admin.user.user_permissions.add(
+            Permission.objects.get(codename='add_recuringjob'))
+        self.area_admin.user.user_permissions.add(
             Permission.objects.get(codename='change_onetimejob'))
         self.area_admin.user.save()
 


### PR DESCRIPTION
…mission

Reproduce: With member that can add jobs but not edit past jobs add a job and leave the time field empty.

This fix also moves the error message, that no past jobs can be added to the time field in the admin.