### PR TITLE
fix required assignment count for trial subs 

### DIFF
--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -147,7 +147,7 @@ class Member(JuntagricoBaseModel):
         return [sm.subscription for sm in
                 self.subscriptionmembership_set.filter(q_left_subscription())]
 
-    def join_subscription(self, subscription):
+    def join_subscription(self, subscription, primary=False):
         sub_membership = self.subscriptionmembership_set.filter(subscription=subscription).first()
         if sub_membership and sub_membership.leave_date:
             sub_membership.leave_date = None
@@ -155,6 +155,9 @@ class Member(JuntagricoBaseModel):
         else:
             join_date = None if subscription.waiting else timezone.now().date()
             SubscriptionMembership.objects.create(member=self, subscription=subscription, join_date=join_date)
+        if primary:
+            subscription.primary_member = self
+            subscription.save()
 
     def leave_subscription(self, subscription, changedate=None):
         sub_membership = self.subscriptionmembership_set.filter(subscription=subscription).first()

--- a/juntagrico/entity/subs.py
+++ b/juntagrico/entity/subs.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.contrib import admin
 from django.db import models
 from django.db.models import Q
@@ -275,9 +277,6 @@ class SubscriptionPart(JuntagricoBaseModel, SimpleStateModel):
         if not self.activation_date:
             return 0
         nominal_required = self.type.required_core_assignments if core else self.type.required_assignments
-        # on trial subs no discount applies
-        if self.type.trial_days:
-            return nominal_required
         # since when part is active in current business year
         start_business = start_of_business_year()
         start = max(self.activation_date, start_business)
@@ -285,8 +284,11 @@ class SubscriptionPart(JuntagricoBaseModel, SimpleStateModel):
         end_business = end = end_of_business_year()
         if self.deactivation_date:
             end = min(self.deactivation_date, end_business)
-        # percentage of business year, where part is active. Do not round here.
-        return nominal_required * (end - start) / (end_business - start_business)
+        elif self.type.trial_days:
+            end = min(self.activation_date + timedelta(self.type.trial_days - 1), end_business)
+        # percentage of business year (or trial period), where part is active. Do not round here.
+        period = timedelta(self.type.trial_days) or (end_business - start_business + timedelta(1))
+        return nominal_required * (end - start + timedelta(1)) / period
 
     def clean(self):
         check_sub_part_consistency(self)

--- a/test/test_assignments.py
+++ b/test/test_assignments.py
@@ -23,6 +23,7 @@ class AssignmentTests(JuntagricoTestCase):
             'description': 'sub_type_desc'}
         self.sub_trial_type = SubscriptionType.objects.create(trial_days=30, **sub_type_data)
 
+        # sub in second half of the year
         year = timezone.now().year
         activation_date = date(day=1, month=7, year=year)
         self.sub2.activation_date = activation_date
@@ -44,19 +45,50 @@ class AssignmentTests(JuntagricoTestCase):
         # sub in first half of the year
         self.sub3 = Subscription.objects.create(**sub_data3)
         SubscriptionPart.objects.create(subscription=self.sub3, type=self.sub_type, **dates)
-        # trial sub
-        self.sub4 = Subscription.objects.create(**sub_data3)
-        SubscriptionPart.objects.create(subscription=self.sub4, type=self.sub_trial_type, **dates)
+        # trial sub ongoing
+        sub_data4 = {**sub_data, 'activation_date': activation_date}
+        self.sub41 = Subscription.objects.create(**sub_data4)
+        SubscriptionPart.objects.create(subscription=self.sub41, type=self.sub_trial_type, activation_date=activation_date)
+        # trial sub shorter than planned
+        self.sub42 = Subscription.objects.create(**sub_data3)
+        dates_short = {**dates, 'deactivation_date': date(day=15, month=1, year=year)}
+        SubscriptionPart.objects.create(subscription=self.sub42, type=self.sub_trial_type, **dates_short)
+        # trial sub at the end of the year
+        dates_year_end = {
+            'activation_date': date(day=15, month=12, year=year),
+            'cancellation_date': date(day=15, month=12, year=year),
+        }
+        sub_data43 = {**sub_data, **dates_year_end}
+        self.sub43 = Subscription.objects.create(**sub_data43)
+        SubscriptionPart.objects.create(subscription=self.sub43, type=self.sub_trial_type, **dates_year_end)
+        # trial sub starting last year
+        dates_year_last = {'activation_date': date(day=15, month=12, year=year - 1)}
+        sub_data44 = {**sub_data, **dates_year_last}
+        self.sub44 = Subscription.objects.create(**sub_data44)
+        SubscriptionPart.objects.create(subscription=self.sub44, type=self.sub_trial_type, **dates_year_last)
         # ordered, not activated sub
         self.sub5 = Subscription.objects.create(**sub_data)
         SubscriptionPart.objects.create(subscription=self.sub5, type=self.sub_type)
 
     def testRequiredAssignments(self):
+        # sub in second half of the year
         self.assertEqual(self.sub2.required_assignments, 5)
         self.assertEqual(self.sub2.required_core_assignments, 2)
+        # sub in first half of the year
         self.assertEqual(self.sub3.required_assignments, 5)
         self.assertEqual(self.sub3.required_core_assignments, 1)  # first 6 months or the year are a bit shorter
-        self.assertEqual(self.sub4.required_assignments, 10)
-        self.assertEqual(self.sub4.required_core_assignments, 3)
+        # trial sub ongoing
+        self.assertEqual(self.sub41.required_assignments, 10)
+        self.assertEqual(self.sub41.required_core_assignments, 3)
+        # trial sub shorter than normal trial period
+        self.assertEqual(self.sub42.required_assignments, 5)
+        self.assertEqual(self.sub42.required_core_assignments, 2)
+        # trial sub at the end of the year
+        self.assertEqual(self.sub43.required_assignments, 6)  # 17/30 rounded
+        self.assertEqual(self.sub43.required_core_assignments, 2)
+        # trial sub starting last year
+        self.assertEqual(self.sub44.required_assignments, 4)  # 13/30 rounded
+        self.assertEqual(self.sub44.required_core_assignments, 1)
+        # ordered, not activated sub
         self.assertEqual(self.sub5.required_assignments, 0)
         self.assertEqual(self.sub5.required_core_assignments, 0)

--- a/test/util/test.py
+++ b/test/util/test.py
@@ -17,6 +17,8 @@ from juntagrico.entity.subtypes import SubscriptionProduct, SubscriptionSize, Su
 @override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
 class JuntagricoTestCase(TestCase):
 
+    _count_sub_types = 0
+
     def setUp(self):
         self.set_up_member()
         self.set_up_admin()
@@ -283,6 +285,21 @@ class JuntagricoTestCase(TestCase):
             'location': self.location_depot}
         self.depot2 = Depot.objects.create(**depot_data)
 
+    @staticmethod
+    def create_sub_type(size, shares=1, visible=True, required_assignments=10, required_core_assignments=3, price=1000, name=None, long_name='sub_type_long_name', **kwargs):
+        JuntagricoTestCase._count_sub_types += 1
+        return SubscriptionType.objects.create(
+            name=name or 'sub_type_name' + str(JuntagricoTestCase._count_sub_types),
+            long_name=long_name,
+            size=size,
+            shares=shares,
+            visible=visible,
+            required_assignments=required_assignments,
+            required_core_assignments=required_core_assignments,
+            price=price,
+            **kwargs
+        )
+
     def set_up_sub_types(self):
         """
         subscription product, size and types
@@ -301,56 +318,44 @@ class JuntagricoTestCase(TestCase):
             'description': 'sub_desc'
         }
         self.sub_size = SubscriptionSize.objects.create(**sub_size_data)
-        sub_type_data = {
-            'name': 'sub_type_name',
-            'long_name': 'sub_type_long_name',
-            'size': self.sub_size,
-            'shares': 1,
-            'visible': True,
-            'required_assignments': 10,
-            'required_core_assignments': 3,
-            'price': 1000,
-            'description': 'sub_type_desc'}
-        self.sub_type = SubscriptionType.objects.create(**sub_type_data)
-        sub_type_data = {
-            'name': 'sub_type_name2',
-            'long_name': 'sub_type_long_name',
-            'size': self.sub_size,
-            'shares': 2,
-            'visible': True,
-            'required_assignments': 10,
-            'required_core_assignments': 3,
-            'price': 1000,
-            'description': 'sub_type_desc'}
-        self.sub_type2 = SubscriptionType.objects.create(**sub_type_data)
+        self.sub_type = self.create_sub_type(self.sub_size)
+        self.sub_type2 = self.create_sub_type(self.sub_size, shares=2)
+
+    @staticmethod
+    def create_sub(depot, activation_date=None, parts=None, **kwargs):
+        if 'deactivation_date' in kwargs and 'cancellation_date' not in kwargs:
+            kwargs['cancellation_date'] = kwargs['deactivation_date']
+        sub = Subscription.objects.create(
+            depot=depot,
+            activation_date=activation_date,
+            creation_date='2017-03-27',
+            start_date='2018-01-01',
+            **kwargs
+        )
+        if parts:
+            for part in parts:
+                SubscriptionPart.objects.create(
+                    subscription=sub,
+                    type=part,
+                    activation_date=activation_date,
+                    cancellation_date=kwargs.get('cancellation_date', None),
+                    deactivation_date=kwargs.get('deactivation_date', None)
+                )
+        return sub
+
+    @classmethod
+    def create_sub_now(cls, depot, **kwargs):
+        return cls.create_sub(depot, timezone.now().date(), **kwargs)
 
     def set_up_sub(self):
         """
         subscription
         """
-        sub_data = {'depot': self.depot,
-                    'future_depot': None,
-                    'activation_date': timezone.now().date(),
-                    'deactivation_date': None,
-                    'creation_date': '2017-03-27',
-                    'start_date': '2018-01-01',
-                    }
-        sub_data2 = {'depot': self.depot,
-                     'future_depot': None,
-                     'activation_date': None,
-                     'deactivation_date': None,
-                     'creation_date': '2017-03-27',
-                     'start_date': '2018-01-01'
-                     }
-        self.sub = Subscription.objects.create(**sub_data)
-        self.sub2 = Subscription.objects.create(**sub_data2)
-        self.member.join_subscription(self.sub)
-        self.sub.primary_member = self.member
-        self.sub.save()
+        self.sub = self.create_sub_now(self.depot)
+        self.sub2 = self.create_sub(self.depot)
+        self.member.join_subscription(self.sub, True)
         self.member3.join_subscription(self.sub)
-        self.member2.join_subscription(self.sub2)
-        self.sub2.primary_member = self.member2
-        self.sub2.save()
+        self.member2.join_subscription(self.sub2, True)
         SubscriptionPart.objects.create(subscription=self.sub, type=self.sub_type, activation_date=timezone.now().date())
 
     def set_up_extra_sub_types(self):

--- a/test/util/test.py
+++ b/test/util/test.py
@@ -286,8 +286,10 @@ class JuntagricoTestCase(TestCase):
         self.depot2 = Depot.objects.create(**depot_data)
 
     @staticmethod
-    def create_sub_type(size, shares=1, visible=True, required_assignments=10, required_core_assignments=3, price=1000, name=None, long_name='sub_type_long_name', **kwargs):
+    def create_sub_type(size, shares=1, visible=True, required_assignments=10, required_core_assignments=3, price=1000, **kwargs):
         JuntagricoTestCase._count_sub_types += 1
+        name = kwargs.get('name', None)
+        long_name = kwargs.get('long_name', 'sub_type_long_name')
         return SubscriptionType.objects.create(
             name=name or 'sub_type_name' + str(JuntagricoTestCase._count_sub_types),
             long_name=long_name,

--- a/test/util/test.py
+++ b/test/util/test.py
@@ -326,7 +326,7 @@ class JuntagricoTestCase(TestCase):
     @staticmethod
     def create_sub(depot, activation_date=None, parts=None, **kwargs):
         if 'deactivation_date' in kwargs and 'cancellation_date' not in kwargs:
-            kwargs['cancellation_date'] = kwargs['deactivation_date']
+            kwargs['cancellation_date'] = activation_date
         sub = Subscription.objects.create(
             depot=depot,
             activation_date=activation_date,


### PR DESCRIPTION
with variable duration and on year change

- If trial is stopped earlier, assignments are discounted, if it takes longer, more assignments are needed.
- Trials around year change now calculate the correct amount of assignments needed in the current year.
- Fix day count in general: the first day of a period was not counted correctly.
