### PR TITLE
fix special chars in plain text emails

### DIFF
--- a/juntagrico/templates/mails/email.txt
+++ b/juntagrico/templates/mails/email.txt
@@ -1,6 +1,8 @@
 {% load juntagrico.config %}
 {% spaceless %}
+{% autoescape off %}
 {% block content %}{% endblock %}
+{% endautoescape %}
 {% endspaceless %}
 ============
 weitere Infos: http://{% config "server_url" %}


### PR DESCRIPTION
characters like apostrophes (') where wrongly HTML escaped in some strings. Disable escaping in general in plain text emails