### PR TITLE
added Field: paid_date to subscription model.

### DIFF
--- a/juntagrico/entity/subs.py
+++ b/juntagrico/entity/subs.py
@@ -36,6 +36,8 @@ class Subscription(Billable, SimpleStateModel):
                                     Config.vocabulary('subscription'), Config.vocabulary('depot'))))
     start_date = models.DateField(
         _('Gewünschtes Startdatum'), null=False, default=start_of_next_business_year)
+    paid_date = models.DateField(
+        _('Bezahlt am'), null=True, blank=True)
     end_date = models.DateField(
         _('Gewünschtes Enddatum'), null=True, blank=True)
     notes = models.TextField(


### PR DESCRIPTION
As of now we maintain a separate excel list to keep track of who paid their subscription. By adding this field we would be able to save this information in juntagrico. The field is analogous to the paid_date field in the share model.

If desired this field could in a further step be displayed in an admin list to allow an overview of all the subscriptions that still need to be paid etc...
In the future this field would ideally be cleared after the cancellation date, since the subscription needs to be paid yearly.