### PR TITLE
Form Text Customization

### DIFF
--- a/docs/intro/advanced.rst
+++ b/docs/intro/advanced.rst
@@ -89,6 +89,9 @@ Roughly these are the steps to override a template:
    while preserving the folder structure.
 3. The project will now use your copy of the template instead of the original.
 
+.. Hint::
+    Some texts, e.g. of forms, do not appear in the template. To change these :ref:`see below <intro-modify-text-in-code>`
+
 
 .. _intro-custom-code:
 
@@ -115,3 +118,29 @@ i.e. in the ``ready`` method of your app config in ``apps.py`` in the main folde
             addons.config.register_user_menu('my_user_menu.html')
             # register other hooks
             # Add Monkey-Patches ..
+
+
+.. _intro-modify-text-in-code:
+
+Modifying Text in Code
+^^^^^^^^^^^^^^^^^^^^^^
+
+Some text is written directly into code instead of templates. These texts can be modified with :ref:`Custom Code <intro-custom-code>`.
+
+.. code-block:: python
+
+    def ready(self):
+        # import the form to patch
+        from juntagrico.forms import RegisterMemberForm
+        # modify text variable (check the form implementation to see if this is available)
+        RegisterMemberForm.text['accept_wo_docs']= 'I accept'
+        # modify field labels of a ModelForm
+        RegisterMemberForm.base_fields['phone'].label = 'Tel'
+        # modify the text in a submit button
+        old_init = RegisterMemberForm.__init__
+
+        def my_init(self, *args, **kwargs):
+            old_init(self, *args, **kwargs)
+            self.helper.layout[-1].fields[0].value = 'Go'
+
+        RegisterMemberForm.__init__ = my_init

--- a/juntagrico/forms.py
+++ b/juntagrico/forms.py
@@ -222,6 +222,17 @@ class RegisterMemberForm(MemberBaseForm):
     comment = CharField(required=False, max_length=4000, label='Kommentar', widget=Textarea(attrs={"rows": 3}))
     agb = BooleanField(required=True)
 
+    documents = {
+        'die Statuten': Config.bylaws,
+        'das Betriebsreglement': Config.business_regulations,
+        'die DSGVO Infos': Config.gdpr_info,
+    }
+    text = {
+        'accept_with_docs': _('Ich habe {} gelesen und erkläre meinen Willen, "{}" beizutreten. Hiermit beantrage ich meine Aufnahme.'),
+        'accept_wo_docs': _('Ich erkläre meinen Willen, "{}" beizutreten. Hiermit beantrage ich meine Aufnahme.'),
+        'and': _('und')
+    }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['agb'].label = self.agb_label()
@@ -235,26 +246,19 @@ class RegisterMemberForm(MemberBaseForm):
         )
         self.fields['email'].error_messages['unique'] = self.duplicate_email_message()
 
-    @staticmethod
-    def agb_label():
-        documents = {
-            'die Statuten': Config.bylaws,
-            'das Betriebsreglement': Config.business_regulations,
-            'die DSGVO Infos': Config.gdpr_info,
-        }
+    @classmethod
+    def agb_label(cls):
         documents_html = []
-        for text, link in documents.items():
+        for text, link in cls.documents.items():
             if link().strip():
                 documents_html.append('<a target="_blank" href="{}">{}</a>'.format(link(), _(text)))
         if documents_html:
-            return _('Ich habe {} gelesen und erkläre meinen Willen, "{}" beizutreten. '
-                     'Hiermit beantrage ich meine Aufnahme.').format(
-                (' ' + _('und') + ' ').join(documents_html),
+            return cls.text['accept_with_docs'].format(
+                (' ' + cls.text['and'] + ' ').join(documents_html),
                 Config.organisation_long_name()
             )
         else:
-            return _('Ich erkläre meinen Willen, "{}" beizutreten. '
-                     'Hiermit beantrage ich meine Aufnahme.').format(Config.organisation_long_name())
+            return cls.text['accept_wo_docs'].format(Config.organisation_long_name())
 
 
 class RegisterSummaryForm(Form):


### PR DESCRIPTION
Form texts can not be modified by template overriding.
Modification should be simplified and the way to do so should be documented.

solves #588 (minimal solution)