### PR TITLE
remove length limitation on all text fields

### DIFF
--- a/juntagrico/entity/billing.py
+++ b/juntagrico/entity/billing.py
@@ -32,8 +32,7 @@ class BillingPeriod(JuntagricoBaseModel):
     cancel_day = models.PositiveIntegerField(_('Kündigungs Tag'))
     cancel_month = models.PositiveIntegerField(
         _('Kündigungs Monat'), choices=month_choices)
-    code = models.TextField(_('Code für Teilabrechnung'),
-                            max_length=1000, default='', blank=True)
+    code = models.TextField(_('Code für Teilabrechnung'), default='', blank=True)
 
     def get_actual_start(self, activation_date=None):
         start = calculate_last(self.start_day, self.start_month)

--- a/juntagrico/entity/depot.py
+++ b/juntagrico/entity/depot.py
@@ -14,7 +14,7 @@ class Tour(JuntagricoBaseModel):
     Delivery Tour to depots
     """
     name = models.CharField(_('Name'), max_length=100, unique=True)
-    description = models.TextField(_('Beschreibung'), max_length=1000, default='', blank=True)
+    description = models.TextField(_('Beschreibung'), default='', blank=True)
     visible_on_list = models.BooleanField(_('Sichtbar auf Listen'), default=True)
     sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)
 
@@ -43,8 +43,8 @@ class Depot(JuntagricoBaseModel):
                              verbose_name=_('Ausfahrt'), blank=True, null=True)
     capacity = models.PositiveIntegerField(_('Kapazität'), default=0)
     location = models.ForeignKey(Location, on_delete=models.PROTECT, verbose_name=_('Ort'))
-    description = models.TextField(_('Beschreibung'), max_length=1000, default='', blank=True)
-    access_information = models.TextField(_('Zugangsbeschreibung'), max_length=1000, default='',
+    description = models.TextField(_('Beschreibung'), default='', blank=True)
+    access_information = models.TextField(_('Zugangsbeschreibung'), default='',
                                           help_text=_('Nur für {0} des/r {1} sichtbar')
                                           .format(Config.vocabulary('member_pl'),
                                                   Config.vocabulary('depot')))

--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -16,8 +16,7 @@ from juntagrico.lifecycle.job import check_job_consistency
 @absolute_url(name='area')
 class ActivityArea(JuntagricoBaseModel):
     name = models.CharField(_('Name'), max_length=100, unique=True)
-    description = models.TextField(
-        _('Beschreibung'), max_length=1000, default='')
+    description = models.TextField(_('Beschreibung'), default='')
     core = models.BooleanField(_('Kernbereich'), default=False)
     hidden = models.BooleanField(
         _('versteckt'), default=False,
@@ -109,7 +108,7 @@ class AbstractJobType(JuntagricoBaseModel):
     name = models.CharField(_('Name'), max_length=100, unique=True,
                             help_text='Eindeutiger Name des Einsatzes')
     displayed_name = models.CharField(_('Angezeigter Name'), max_length=100, blank=True, null=True)
-    description = models.TextField(_('Beschreibung'), max_length=1000, default='')
+    description = models.TextField(_('Beschreibung'), default='')
     activityarea = models.ForeignKey(ActivityArea, on_delete=models.PROTECT, verbose_name=_('Tätigkeitsbereich'))
     default_duration = models.FloatField(_('Dauer in Stunden'),
                                          help_text='Standard-Dauer für diese Jobart', validators=[MinValueValidator(0)])
@@ -268,7 +267,7 @@ class Job(JuntagricoBasePoly):
 
 class RecuringJob(Job):
     type = models.ForeignKey(JobType, on_delete=models.PROTECT, verbose_name=_('Jobart'))
-    additional_description = models.TextField(_('Zusätzliche Beschreibung'), max_length=1000, blank=True, default='')
+    additional_description = models.TextField(_('Zusätzliche Beschreibung'), blank=True, default='')
     duration_override = models.FloatField(
         _('Dauer in Stunden (Überschreibend)'), null=True, blank=True, default=None, validators=[MinValueValidator(0)],
         help_text=_('Wenn nicht angegeben, wird die Standard-Dauer von der Jobart übernommen.')

--- a/juntagrico/entity/location.py
+++ b/juntagrico/entity/location.py
@@ -20,7 +20,7 @@ class Location(JuntagricoBaseModel):
                                     null=True, blank=True)
     addr_location = models.CharField(_('Ort'), max_length=50,
                                      null=True, blank=True)
-    description = models.TextField(_('Beschreibung'), max_length=1000, default='', blank=True)
+    description = models.TextField(_('Beschreibung'), default='', blank=True)
     visible = models.BooleanField(_('Sichtbar'), default=True,
                                   help_text=_('Ort steht bei Einsatz und {} zur Auswahl').format(
                                       Config.vocabulary('depot')))

--- a/juntagrico/entity/mailing.py
+++ b/juntagrico/entity/mailing.py
@@ -9,8 +9,8 @@ class MailTemplate(JuntagricoBaseModel):
     Mail template for rendering
     '''
     name = models.CharField(_('Name'), max_length=100, unique=True)
-    template = models.TextField(_('Template'), max_length=1000, default='')
-    code = models.TextField(_('Code'), max_length=1000, default='')
+    template = models.TextField(_('Template'), default='')
+    code = models.TextField(_('Code'), default='')
 
     def __str__(self):
         return self.name

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -59,8 +59,7 @@ class Member(JuntagricoBaseModel):
         _('Deaktivierungsdatum'), null=True, blank=True, help_text=_('Sperrt Login und entfernt von E-Mail-Listen'))
     end_date = models.DateField(
         _('Enddatum'), null=True, blank=True, help_text=_('Voraususchtliches Datum an dem die Mitgliedschaft enden wird. Hat keinen Effekt im System'))
-    notes = models.TextField(
-        _('Notizen'), max_length=1000, blank=True,
+    notes = models.TextField(_('Notizen'), blank=True,
         help_text=_('Notizen für Administration. Nicht sichtbar für {}'.format(Config.vocabulary('member'))))
     number = models.IntegerField(_('Mitglieder-Nummer'), null=True, blank=True)
 

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -59,7 +59,8 @@ class Member(JuntagricoBaseModel):
         _('Deaktivierungsdatum'), null=True, blank=True, help_text=_('Sperrt Login und entfernt von E-Mail-Listen'))
     end_date = models.DateField(
         _('Enddatum'), null=True, blank=True, help_text=_('Voraususchtliches Datum an dem die Mitgliedschaft enden wird. Hat keinen Effekt im System'))
-    notes = models.TextField(_('Notizen'), blank=True,
+    notes = models.TextField(
+        _('Notizen'), blank=True,
         help_text=_('Notizen für Administration. Nicht sichtbar für {}'.format(Config.vocabulary('member'))))
     number = models.IntegerField(_('Mitglieder-Nummer'), null=True, blank=True)
 

--- a/juntagrico/entity/share.py
+++ b/juntagrico/entity/share.py
@@ -43,8 +43,7 @@ class Share(Billable):
         _('Grund des Erwerbs'), null=True, blank=True, choices=reason_for_acquisition_choices)
     reason_for_cancellation = models.PositiveIntegerField(
         _('Grund der Kündigung'), null=True, blank=True, choices=reason_for_cancellation_choices)
-    notes = models.TextField(
-        _('Notizen'), max_length=1000, default='', blank=True,
+    notes = models.TextField(_('Notizen'), default='', blank=True,
         help_text=_('Notizen für Administration. Nicht sichtbar für {}'.format(Config.vocabulary('member'))))
 
     __state_text_dict = {0: _('unbezahlt'),

--- a/juntagrico/entity/share.py
+++ b/juntagrico/entity/share.py
@@ -43,7 +43,8 @@ class Share(Billable):
         _('Grund des Erwerbs'), null=True, blank=True, choices=reason_for_acquisition_choices)
     reason_for_cancellation = models.PositiveIntegerField(
         _('Grund der Kündigung'), null=True, blank=True, choices=reason_for_cancellation_choices)
-    notes = models.TextField(_('Notizen'), default='', blank=True,
+    notes = models.TextField(
+        _('Notizen'), default='', blank=True,
         help_text=_('Notizen für Administration. Nicht sichtbar für {}'.format(Config.vocabulary('member'))))
 
     __state_text_dict = {0: _('unbezahlt'),

--- a/juntagrico/entity/subs.py
+++ b/juntagrico/entity/subs.py
@@ -40,7 +40,8 @@ class Subscription(Billable, SimpleStateModel):
         _('Gewünschtes Startdatum'), null=False, default=start_of_next_business_year)
     end_date = models.DateField(
         _('Gewünschtes Enddatum'), null=True, blank=True)
-    notes = models.TextField(_('Notizen'), blank=True,
+    notes = models.TextField(
+        _('Notizen'), blank=True,
         help_text=_('Notizen für Administration. Nicht sichtbar für {}'.format(Config.vocabulary('member'))))
 
     objects = PolymorphicManager.from_queryset(SubscriptionQuerySet)()

--- a/juntagrico/entity/subs.py
+++ b/juntagrico/entity/subs.py
@@ -40,8 +40,7 @@ class Subscription(Billable, SimpleStateModel):
         _('Gewünschtes Startdatum'), null=False, default=start_of_next_business_year)
     end_date = models.DateField(
         _('Gewünschtes Enddatum'), null=True, blank=True)
-    notes = models.TextField(
-        _('Notizen'), max_length=1000, blank=True,
+    notes = models.TextField(_('Notizen'), blank=True,
         help_text=_('Notizen für Administration. Nicht sichtbar für {}'.format(Config.vocabulary('member'))))
 
     objects = PolymorphicManager.from_queryset(SubscriptionQuerySet)()

--- a/juntagrico/entity/subtypes.py
+++ b/juntagrico/entity/subtypes.py
@@ -11,8 +11,7 @@ class SubscriptionProduct(JuntagricoBaseModel):
     Product of subscription
     '''
     name = models.CharField(_('Name'), max_length=100, unique=True)
-    description = models.TextField(
-        _('Beschreibung'), max_length=1000, blank=True)
+    description = models.TextField(_('Beschreibung'), blank=True)
     sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)
     is_extra = models.BooleanField(_('Ist Zusatzabo Produkt'), default=False)
 
@@ -39,8 +38,7 @@ class SubscriptionSize(JuntagricoBaseModel):
     depot_list = models.BooleanField(
         _('Sichtbar auf Depotliste'), default=True)
     visible = models.BooleanField(_('Sichtbar'), default=True)
-    description = models.TextField(
-        _('Beschreibung'), max_length=1000, blank=True)
+    description = models.TextField(_('Beschreibung'), blank=True)
     product = models.ForeignKey('SubscriptionProduct', on_delete=models.PROTECT,
                                 related_name='sizes', verbose_name=_('Produkt'))
 
@@ -74,8 +72,7 @@ class SubscriptionType(JuntagricoBaseModel):
     visible = models.BooleanField(_('Sichtbar'), default=True)
     trial = models.BooleanField(_('Probe-Abo'), default=False)
     trial_days = models.IntegerField(_('Probe-Abo Dauer in Tagen'), default=0)
-    description = models.TextField(
-        _('Beschreibung'), max_length=1000, blank=True)
+    description = models.TextField(_('Beschreibung'), blank=True)
     sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)
 
     @property

--- a/juntagrico/migrations/0038_pre_1_6.py
+++ b/juntagrico/migrations/0038_pre_1_6.py
@@ -68,7 +68,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=100, unique=True, verbose_name='Name')),
-                ('description', models.TextField(blank=True, default='', max_length=1000, verbose_name='Beschreibung')),
+                ('description', models.TextField(blank=True, default='', verbose_name='Beschreibung')),
                 ('visible_on_list', models.BooleanField(default=True, verbose_name='Sichtbar auf Listen')),
                 ('sort_order', models.PositiveIntegerField(default=0, verbose_name='Reihenfolge')),
             ],
@@ -96,5 +96,90 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name='delivery',
             constraint=models.UniqueConstraint(fields=('delivery_date', 'tour', 'subscription_size'), name='unique_delivery'),
+        ),
+        migrations.AlterField(
+            model_name='activityarea',
+            name='description',
+            field=models.TextField(default='', verbose_name='Beschreibung'),
+        ),
+        migrations.AlterField(
+            model_name='billingperiod',
+            name='code',
+            field=models.TextField(blank=True, default='', verbose_name='Code für Teilabrechnung'),
+        ),
+        migrations.AlterField(
+            model_name='depot',
+            name='access_information',
+            field=models.TextField(default='', help_text='Nur für Mitglieder des/r Depot sichtbar',
+                                   verbose_name='Zugangsbeschreibung'),
+        ),
+        migrations.AlterField(
+            model_name='depot',
+            name='description',
+            field=models.TextField(blank=True, default='', verbose_name='Beschreibung'),
+        ),
+        migrations.AlterField(
+            model_name='jobtype',
+            name='description',
+            field=models.TextField(default='', verbose_name='Beschreibung'),
+        ),
+        migrations.AlterField(
+            model_name='location',
+            name='description',
+            field=models.TextField(blank=True, default='', verbose_name='Beschreibung'),
+        ),
+        migrations.AlterField(
+            model_name='mailtemplate',
+            name='code',
+            field=models.TextField(default='', verbose_name='Code'),
+        ),
+        migrations.AlterField(
+            model_name='mailtemplate',
+            name='template',
+            field=models.TextField(default='', verbose_name='Template'),
+        ),
+        migrations.AlterField(
+            model_name='member',
+            name='notes',
+            field=models.TextField(blank=True, help_text='Notizen für Administration. Nicht sichtbar für Mitglied',
+                                   verbose_name='Notizen'),
+        ),
+        migrations.AlterField(
+            model_name='onetimejob',
+            name='description',
+            field=models.TextField(default='', verbose_name='Beschreibung'),
+        ),
+        migrations.AlterField(
+            model_name='recuringjob',
+            name='additional_description',
+            field=models.TextField(blank=True, default='', verbose_name='Zusätzliche Beschreibung'),
+        ),
+        migrations.AlterField(
+            model_name='share',
+            name='notes',
+            field=models.TextField(blank=True, default='',
+                                   help_text='Notizen für Administration. Nicht sichtbar für Mitglied',
+                                   verbose_name='Notizen'),
+        ),
+        migrations.AlterField(
+            model_name='subscription',
+            name='notes',
+            field=models.TextField(blank=True, help_text='Notizen für Administration. Nicht sichtbar für Mitglied',
+                                   verbose_name='Notizen'),
+        ),
+        migrations.AlterField(
+            model_name='subscriptionproduct',
+            name='description',
+            field=models.TextField(blank=True, verbose_name='Beschreibung'),
+        ),
+        migrations.AlterField(
+            model_name='subscriptionsize',
+            name='description',
+            field=models.TextField(blank=True, verbose_name='Beschreibung'),
+        ),
+        migrations.AlterField(
+            model_name='subscriptiontype',
+            name='description',
+            field=models.TextField(blank=True, verbose_name='Beschreibung'),
         ),
     ]


### PR DESCRIPTION
fixes #602

# Release Notes

## Admin Features

- Removed all length limitations on text area fields. Including for mail templates.