### PR TITLE
Use the SUMMARY property of the Event instead of NAME for the event title

### DIFF
--- a/juntagrico/util/ical.py
+++ b/juntagrico/util/ical.py
@@ -24,7 +24,7 @@ def generate_ical_for_job(job):
     # By giving it a UID the calendar will (hopefully) replace previous versions of this event.
     e.add(name='UID', value=f'{repr(job)}@{Config.server_url()}')
     e['DTSTAMP'] = vDatetime(timezone.now()).to_ical()
-    e.add(name='NAME', value=Config.organisation_name() + ' ' + _('Einsatz') + ': ' + job.type.get_name)
+    e.add(name='SUMMARY', value=Config.organisation_name() + ' ' + _('Einsatz') + ': ' + job.type.get_name)
     e.add(name='LOCATION', value=job.type.location)
     e.add(name='DESCRIPTION', value=job.type.description)
     e['DTSTART'] = vDatetime(job.start_time()).to_ical()


### PR DESCRIPTION
For some reason, NAME doesn't seem to work. When setting the 'NAME' property of the event, the title is empty. 

However, using 'SUMMARY' properly populates the title. I have tested by generating an ical event by subscribing to a job then importing it in both Google Calendar and Apple Calendar. 

With both, using 'SUMMARY', the event had the appropriate title.