### PR TITLE
Fix leaflet marker icon when using ManifestStaticFileStorage

### DIFF
--- a/juntagrico/templates/createsubscription/select_depot.html
+++ b/juntagrico/templates/createsubscription/select_depot.html
@@ -60,7 +60,7 @@
         {{ selected.name|json_script:'selected_depot' }}
     {% endif %}
     {{ depots.map_info|json_script:'depots' }}
-  <script type="text/javascript" src="{% static 'juntagrico/external/leaflet/leaflet.js' %}"></script>
-    <script type="text/javascript" src="{% static 'juntagrico/external/require.min.js' %}"data-main="{% static 'juntagrico/js/initCreateSubscription.js' %}">
+    {% include 'snippets/scripts/leaflet.html' %}
+    <script type="text/javascript" src="{% static 'juntagrico/external/require.min.js' %}" data-main="{% static 'juntagrico/js/initCreateSubscription.js' %}">
      </script>
 {% endblock %}

--- a/juntagrico/templates/depot.html
+++ b/juntagrico/templates/depot.html
@@ -67,7 +67,7 @@
 {% endblock %}
 {% block scripts %}
     {{ depot.map_info|json_script:'depot_data' }}
-    <script type="text/javascript" src="{% static 'juntagrico/external/leaflet/leaflet.js' %}"></script>
+    {% include 'snippets/scripts/leaflet.html' %}
     <script type="text/javascript" src="{% static 'juntagrico/external/require.min.js' %}" data-main="{% static 'juntagrico/js/initDepot.js' %}">
     </script>
 {% endblock %}

--- a/juntagrico/templates/depot_change.html
+++ b/juntagrico/templates/depot_change.html
@@ -76,7 +76,7 @@
 {% block scripts %}
     {{ subscription.depot.name|json_script:'selected_depot' }}
     {{ depots.map_info|json_script:'depots' }}
-    <script type="text/javascript" src="{% static 'juntagrico/external/leaflet/leaflet.js' %}"></script>
-    <script type="text/javascript" src="{% static 'juntagrico/external/require.min.js' %}"data-main="{% static 'juntagrico/js/initChangeDepot.js' %}">
+    {% include 'snippets/scripts/leaflet.html' %}
+    <script type="text/javascript" src="{% static 'juntagrico/external/require.min.js' %}" data-main="{% static 'juntagrico/js/initChangeDepot.js' %}">
     </script>
 {% endblock %}

--- a/juntagrico/templates/job.html
+++ b/juntagrico/templates/job.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load juntagrico.common %}
 {% load juntagrico.config %}
+{% load static %}
 {% block page_title %}
     <h3>
         {{ job.type.get_name }}
@@ -14,7 +15,7 @@
     </h3>
 {% endblock %}
 {% block styles %}
-    <link rel="stylesheet" href="/static/juntagrico/external/leaflet/leaflet.css" />
+    <link rel="stylesheet" href="{% static 'juntagrico/external/leaflet/leaflet.css' %}" />
 {% endblock %}
 {% block content %}
     {% vocabulary "assignment_pl" as v_assignment_pl %}
@@ -233,7 +234,7 @@
 {% endblock %}
 {% block scripts %}
     {{ job.type.location.map_info|json_script:'location_data' }}
-    <script type="text/javascript" src="/static/juntagrico/external/leaflet/leaflet.js"></script>
-    <script type="text/javascript" src="/static/juntagrico/external/require.min.js" data-main="/static/juntagrico/js/initJob.js">
+    {% include 'snippets/scripts/leaflet.html' %}
+    <script type="text/javascript" src="{% static 'juntagrico/external/require.min.js' %}" data-main="{% static 'juntagrico/js/initJob.js' %}">
     </script>
 {% endblock %}

--- a/juntagrico/templates/snippets/scripts/leaflet.html
+++ b/juntagrico/templates/snippets/scripts/leaflet.html
@@ -1,0 +1,6 @@
+{% load static %}
+<script type="text/javascript" src="{% static 'juntagrico/external/leaflet/leaflet.js' %}"></script>
+<script type="text/javascript">
+    // Fix icon when using ManifestStaticFileStorage https://github.com/juntagrico/juntagrico/issues/618
+    L.Icon.Default.prototype.options.imagePath = "{% static 'juntagrico/external/leaflet/images/' %}";
+</script>


### PR DESCRIPTION
fixes #618

Note: The marker icon worked already before, because it didn't use the `{% static %}` template function for the leaflet css. This was unclean so it was fixed as well.