### PR TITLE
escape contacts in job reminder email

### DIFF
--- a/juntagrico/templates/mails/member/job_reminder.txt
+++ b/juntagrico/templates/mails/member/job_reminder.txt
@@ -15,7 +15,7 @@ Am {{ jt }}-{{ jet }} findet dein {{ c_organisation_name }}-Arbeitseinsatz "{{ j
 {% trans "Zeit" %}:            {{ job.time |date:"d.m.Y H:i" }}-{{ job.end_time|date:"H:i" }}
 {% trans "Ort" %}:             {{ job.type.location }}
 {% trans "Teilnehmer" %}:      {{ job.participant_names }}
-{% trans "Kontakt" %}:         {{ job.contacts|join:"  " }}
+{% trans "Kontakt" %}:         {% for contact in job.contacts %}{{ contact|escape }} {% endfor %}
 {% blocktrans trimmed %}
 Wir freuen uns, dich zu sehen und zählen auf dich!
 {% endblocktrans %}


### PR DESCRIPTION
addresses https://github.com/juntagrico/juntagrico/issues/619

Resulting email would look as shown below.
One could argue that there should be some punctuation or orther forms of separation between different contants and or user emails. Happy to look into it if needed. 

![image](https://github.com/juntagrico/juntagrico/assets/32741304/4ffc9ee2-5609-45fe-a822-d944adf560d7)
