### PR TITLE
More granular mail send permissions

### DIFF
--- a/juntagrico/migrations/0038_pre_1_6.py
+++ b/juntagrico/migrations/0038_pre_1_6.py
@@ -16,12 +16,20 @@ class Migration(migrations.Migration):
         migrations.AlterModelOptions(
             name='specialroles',
             options={'default_permissions': (), 'managed': False, 'permissions': (
-                ('is_operations_group', 'Benutzer ist in der BG'), ('is_book_keeper', 'Benutzer ist Buchhalter'), ('can_send_mails', 'Benutzer kann im System E-Mails versenden'),
-                ('can_use_general_email', 'Benutzer kann allgemeine E-Mail-Adresse verwenden'), ('can_use_for_members_email', 'Benutzer kann E-Mail-Adresse "for_members" verwenden'),
-                ('can_use_for_subscriptions_email', 'Benutzer kann E-Mail-Adresse "for_subscription" verwenden'), ('can_use_for_shares_email', 'Benutzer kann E-Mail-Adresse "for_shares" verwenden'),
-                ('can_use_technical_email', 'Benutzer kann technische E-Mail-Adresse verwenden'), ('depot_list_notification', 'Benutzer wird bei Depot-Listen-Erstellung informiert'),
-                ('can_view_exports', 'Benutzer kann Exporte öffnen'), ('can_view_lists', 'Benutzer kann Listen öffnen'), ('can_generate_lists', 'Benutzer kann Listen erzeugen')
-            )},
+            ('is_operations_group', 'Ist in der BG'), ('is_book_keeper', 'Ist Buchhalter'),
+            ('can_send_mails', 'Kann E-Mails versenden'),
+            ('can_use_general_email', 'Kann Haupt-E-Mail-Adresse verwenden'),
+            ('can_use_for_members_email', 'Kann E-Mail-Adresse "for_members" verwenden'),
+            ('can_use_for_subscriptions_email', 'Kann E-Mail-Adresse "for_subscription" verwenden'),
+            ('can_use_for_shares_email', 'Kann E-Mail-Adresse "for_shares" verwenden'),
+            ('can_use_technical_email', 'Kann technische E-Mail-Adresse verwenden'),
+            ('can_email_all_in_system', 'Kann E-Mails an alle im System senden'),
+            ('can_email_all_with_share', 'Kann E-Mails an alle mit Anteilschein senden'),
+            ('can_email_all_with_sub', 'Kann E-Mails an alle mit Abo senden'),
+            ('can_email_free_address_list', 'Kann E-Mails frei an Adressen senden'),
+            ('depot_list_notification', 'Benutzer wird bei Depot-Listen-Erstellung informiert'),
+            ('can_view_exports', 'Kann Exporte öffnen'), ('can_view_lists', 'Kann Listen öffnen'),
+            ('can_generate_lists', 'Kann Listen erzeugen'))},
         ),
         migrations.AlterField(
             model_name='subscriptionmembership',

--- a/juntagrico/migrations/0039_data_1_6.py
+++ b/juntagrico/migrations/0039_data_1_6.py
@@ -34,6 +34,12 @@ def set_tour(apps, schema_editor):
         d.tour = tour.objects.get_or_create(name=weekdays[d.delivery_date.weekday() + 1])[0]
         d.save()
 
+def mail_send_permissions_forward(apps, schema_editor):
+    pass
+
+def mail_send_permissions_backwards(apps, schema_editor):
+    pass
+
 
 class Migration(migrations.Migration):
 
@@ -45,4 +51,5 @@ class Migration(migrations.Migration):
         migrations.RunPython(set_location_sort_order),
         migrations.RunPython(make_name_product_unique),
         migrations.RunPython(set_tour),
+        migrations.RunPython(mail_send_permissions_forward, mail_send_permissions_backwards),
     ]

--- a/juntagrico/models.py
+++ b/juntagrico/models.py
@@ -30,21 +30,26 @@ class SpecialRoles(models.Model):
     class Meta:
         managed = False
         default_permissions = ()
-        permissions = (('is_operations_group', _('Benutzer ist in der BG')),
-                       ('is_book_keeper', _('Benutzer ist Buchhalter')),
-                       ('can_send_mails', _('Benutzer kann im System E-Mails versenden')),
-                       ('can_use_general_email', _('Benutzer kann allgemeine E-Mail-Adresse verwenden')),
-                       ('can_use_for_members_email', _('Benutzer kann E-Mail-Adresse "for_members" verwenden')),
-                       ('can_use_for_subscriptions_email', _('Benutzer kann E-Mail-Adresse "for_subscription" verwenden')),
-                       ('can_use_for_shares_email', _('Benutzer kann E-Mail-Adresse "for_shares" verwenden')),
-                       ('can_use_technical_email', _('Benutzer kann technische E-Mail-Adresse verwenden')),
+        permissions = (('is_operations_group', _('Ist in der BG')),
+                       ('is_book_keeper', _('Ist Buchhalter')),
+                       ('can_send_mails', _('Kann E-Mails versenden')),
+                       ('can_use_general_email', _('Kann Haupt-E-Mail-Adresse verwenden')),
+                       ('can_use_for_members_email', _('Kann E-Mail-Adresse "for_members" verwenden')),
+                       ('can_use_for_subscriptions_email', _('Kann E-Mail-Adresse "for_subscription" verwenden')),
+                       ('can_use_for_shares_email', _('Kann E-Mail-Adresse "for_shares" verwenden')),
+                       ('can_use_technical_email', _('Kann technische E-Mail-Adresse verwenden')),
+                       ('can_email_all_in_system', _('Kann E-Mails an alle im System senden')),
+                       ('can_email_all_with_share',
+                        _('Kann E-Mails an alle mit {0} senden').format(Config.vocabulary('share'))),
+                       ('can_email_all_with_sub',
+                        _('Kann E-Mails an alle mit {0} senden').format(Config.vocabulary('subscription'))),
+                       ('can_email_free_address_list', _('Kann E-Mails frei an Adressen senden')),
                        ('depot_list_notification',
                         _('Benutzer wird bei {0}-Listen-Erstellung informiert').format(Config.vocabulary('depot'))),
-                       ('can_view_exports', _('Benutzer kann Exporte öffnen')),
-                       ('can_view_lists', _('Benutzer kann Listen öffnen')),
-                       ('can_generate_lists', _('Benutzer kann Listen erzeugen')),
+                       ('can_view_exports', _('Kann Exporte öffnen')),
+                       ('can_view_lists', _('Kann Listen öffnen')),
+                       ('can_generate_lists', _('Kann Listen erzeugen')),
                        )
-
 
 ''' non lifecycle related signals '''
 signals.pre_save.connect(Member.create, sender=Member)

--- a/juntagrico/templates/mail_sender.html
+++ b/juntagrico/templates/mail_sender.html
@@ -81,6 +81,7 @@
                     {% trans "Wähle mindestens eine der folgenden Gruppen" %}:
                 </div>
             </div>
+            {% if perms.juntagrico.can_email_all_with_sub %}
             <div class="form-group row">
                 <div class="offset-md-2 col-md-1">
                     <span class="switch switch-sm">
@@ -95,7 +96,8 @@
                     {% endblocktrans %}
                 </label>
             </div>
-            {% if enable_shares %}
+            {% endif %}
+            {% if enable_shares and perms.juntagrico.can_email_all_with_share %}
                 <div class="form-group row">
                     <div class=" offset-md-2 col-md-1">
                         <span class="switch switch-sm">
@@ -111,6 +113,7 @@
                     </label>
                 </div>
             {% endif %}
+            {% if perms.juntagrico.can_email_all_in_system %}
             <div class="form-group row">
                 <div class="offset-md-2 col-md-1">
                     <span class="switch switch-sm">
@@ -123,6 +126,8 @@
                     {% trans "Alle im System" %}
                 </label>
             </div>
+            {% endif %}
+            {% if perms.juntagrico.can_email_free_address_list %}
             <div class="form-group row">
                 <div class="offset-md-2 col-md-1">
                     <span class="switch switch-sm">
@@ -140,6 +145,7 @@
                     <input type="text" class="form-control" id="singleemail" name="singleemail"placeholder="{% trans "Nur an diese Email" %}" style="display:none"/>
                 </div>
             </div>
+            {% endif %}
         {% endif %}
         <div class="form-group row">
             <label for="subject" class="col-md-2">

--- a/juntagrico/views_admin.py
+++ b/juntagrico/views_admin.py
@@ -65,19 +65,15 @@ def send_email_intern(request):
         raise Http404
     emails = set()
     sender = request.POST.get('sender')
-    if request.POST.get('allsubscription') == 'on':
-        m_emails = MemberDao.members_for_email_with_subscription().values_list('email',
-                                                                               flat=True)
-        emails.update(m_emails)
-    if request.POST.get('allshares') == 'on':
-        emails.update(MemberDao.members_for_email_with_shares(
-        ).values_list('email', flat=True))
-    if request.POST.get('all') == 'on':
-        emails.update(MemberDao.members_for_email(
-        ).values_list('email', flat=True))
+    if request.POST.get('allsubscription') == 'on' and request.user.has_perm('juntagrico.can_email_all_with_sub'):
+        emails.update(MemberDao.members_for_email_with_subscription().values_list('email', flat=True))
+    if request.POST.get('allshares') == 'on' and request.user.has_perm('juntagrico.can_email_all_with_share'):
+        emails.update(MemberDao.members_for_email_with_shares().values_list('email', flat=True))
+    if request.POST.get('all') == 'on' and request.user.has_perm('juntagrico.can_email_all_in_system'):
+        emails.update(MemberDao.members_for_email().values_list('email', flat=True))
     if request.POST.get('recipients'):
         emails.update(re.split(r'[\s,;]+', request.POST.get('recipients')))
-    if request.POST.get('allsingleemail'):
+    if request.POST.get('allsingleemail') and request.user.has_perm('juntagrico.can_email_free_address_list'):
         emails.update(re.split(r'[\s,;]+', request.POST.get('singleemail')))
 
     files = []


### PR DESCRIPTION
We need to limit the scope of mails that are sent. Too many mails go out with a too wide recipient list annoying people.

- [x] Implement new permissions
- [ ] Add all new permissions for users/groups during migration based on existing permission 'can_send_mails'
- [ ] Remove buttons/links to send mail in member/subscription list based on new permissions
- [ ] Check & harden send mail functions to represent selected permissions