### PR TITLE
More arguments to generate test data, and fixed subscriptions added.

### DIFF
--- a/juntagrico/management/commands/generate_testdata_advanced.py
+++ b/juntagrico/management/commands/generate_testdata_advanced.py
@@ -1,6 +1,5 @@
 ﻿import math
 import random
-import itertools
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone

--- a/juntagrico/management/commands/generate_testdata_advanced.py
+++ b/juntagrico/management/commands/generate_testdata_advanced.py
@@ -125,8 +125,8 @@ class Command(BaseCommand):
         self.generate_subscription(main_member, co_member, depot, sub_types)
 
     def add_arguments(self, parser):
-        parser.add_argument('--products', type=str, help='Products to use', default=["Gemüse"], nargs="+")
-        parser.add_argument('--sub-size', type=int, help='Size of subscription', default=[1], nargs="+")
+        parser.add_argument('--products', type=str, help='Products[/size1,size2,...] to use', default=["Gemüse/1"], nargs="+")
+        parser.add_argument('--sub-size', type=int, help='Default size of subscription', default=1)
         parser.add_argument('--sub-shares', type=int, help='Required shares per subscription', default=2)
         parser.add_argument('--sub-assignments', type=int, help='Required assignment per subscription', default=6)
         parser.add_argument('--sub-price', type=int, help='Price of suscription', default=250)
@@ -138,33 +138,40 @@ class Command(BaseCommand):
     # entry point used by manage.py
     def handle(self, *args, **options):
         sub_types = []
-        for product, size in itertools.zip_longest(options['products'], options['sub_size']):
-            size = size or 1
+        default_size = options['sub_size']
+        for product_sizes in options['products']:
+            product_sizes_parts = product_sizes.split('/')
+            product = product_sizes_parts[0]
+            if product_sizes_parts[1:]:
+                product_sizes = map(int, product_sizes_parts[1].split(','))
+            else:
+                product_sizes = [default_size]
 
             subprod_field = {'name': product}
             sub_product, created = SubscriptionProduct.objects.get_or_create(**subprod_field)
-            subsize_fields = {
-                'name': random.choice(['Tasche', 'Portion', '500g']), 'units': size,
-                'depot_list': True,
-                'description': 'Das einzige abo welches wir haben, bietet genug Gemüse für einen Zwei personen Haushalt für eine Woche.',
-                'product': sub_product
-            }
-            size, _ = SubscriptionSize.objects.get_or_create(**subsize_fields)
+            for size in product_sizes:
+                subsize_fields = {
+                    'name': random.choice(['Tasche', 'Portion', '500g']), 'units': size,
+                    'depot_list': True,
+                    'description': 'Das einzige abo welches wir haben, bietet genug Gemüse für einen Zwei personen Haushalt für eine Woche.',
+                    'product': sub_product
+                }
+                size, _ = SubscriptionSize.objects.get_or_create(**subsize_fields)
 
-            subtype_fields = {
-                'name': 'Abo {}'.format(product),
-                'long_name': 'Ganz Normales {} Abo'.format(product),
-                'shares': options['sub_shares'],
-                'required_assignments': options['sub_assignments'],
-                'price': options['sub_price'],
-                'description': '',
-                'size': size
-            }
-            sub_type, _ = SubscriptionType.objects.get_or_create(
-                name=subtype_fields['name'],
-                defaults=subtype_fields
-            )
-            sub_types.append(sub_type)
+                subtype_fields = {
+                    'name': 'Abo {}'.format(product),
+                    'long_name': 'Ganz Normales {} Abo'.format(product),
+                    'shares': options['sub_shares'],
+                    'required_assignments': options['sub_assignments'],
+                    'price': options['sub_price'],
+                    'description': '',
+                    'size': size
+                }
+                sub_type, _ = SubscriptionType.objects.get_or_create(
+                    name=subtype_fields['name'],
+                    defaults=subtype_fields
+                )
+                sub_types.append(sub_type)
 
         for i in range(0, options['depots']):
             props = self.get_random_props()

--- a/juntagrico/management/commands/generate_testdata_advanced.py
+++ b/juntagrico/management/commands/generate_testdata_advanced.py
@@ -1,7 +1,6 @@
 ﻿import math
 import random
 import itertools
-import datetime
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone
@@ -144,11 +143,12 @@ class Command(BaseCommand):
 
             subprod_field = {'name': product}
             sub_product, created = SubscriptionProduct.objects.get_or_create(**subprod_field)
-            print("generated", sub_product.name)
-            subsize_fields = {'name': random.choice(['Tasche', 'Portion', '500g']), 'units': size,
-                            'depot_list': True,
-                            'description': 'Das einzige abo welches wir haben, bietet genug Gemüse für einen Zwei personen Haushalt für eine Woche.',
-                            'product': sub_product}
+            subsize_fields = {
+                'name': random.choice(['Tasche', 'Portion', '500g']), 'units': size,
+                'depot_list': True,
+                'description': 'Das einzige abo welches wir haben, bietet genug Gemüse für einen Zwei personen Haushalt für eine Woche.',
+                'product': sub_product
+            }
             size, _ = SubscriptionSize.objects.get_or_create(**subsize_fields)
 
             subtype_fields = {
@@ -179,7 +179,6 @@ class Command(BaseCommand):
             self.generate_subscription(main_member, co_member, depot, sub_types)
             for _ in range(1, options['subs_per_depot']):
                 random_sub_types = random.choices(sub_types, k=(len(sub_types)+1)//2)
-                print("generate random abos", ", ".join([st.name for st in random_sub_types]))
                 self.generate_depot_sub(depot, options['sub_shares'], random_sub_types)
 
         area1_fields = {'name': 'Ernten', 'description': 'Das Gemüse aus der Erde Ziehen', 'core': True,

--- a/juntagrico/management/commands/generate_testdata_advanced.py
+++ b/juntagrico/management/commands/generate_testdata_advanced.py
@@ -1,4 +1,7 @@
 ﻿import math
+import random
+import itertools
+import datetime
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone
@@ -9,7 +12,7 @@ from juntagrico.entity.jobs import ActivityArea, JobType, RecuringJob
 from juntagrico.entity.location import Location
 from juntagrico.entity.member import Member
 from juntagrico.entity.share import Share
-from juntagrico.entity.subs import Subscription
+from juntagrico.entity.subs import Subscription, SubscriptionPart
 from juntagrico.entity.subtypes import SubscriptionProduct, SubscriptionSize, SubscriptionType
 
 fake = Faker()
@@ -54,9 +57,9 @@ class Command(BaseCommand):
             share_dict = self.generate_share_dict(member)
             Share.objects.create(**share_dict)
 
-    def generate_depot(self, props, member, i):
+    def generate_depot(self, props, member, i, days):
         location_dict = {
-            'name': fake.company(),
+            'name': "{}_{}".format(fake.company(), i),
             'addr_street': '{} {}'.format(props['strasselang'], props['hnr']),
             'addr_zipcode': props['plz'],
             'addr_location': props['ort'],
@@ -72,13 +75,13 @@ class Command(BaseCommand):
                 'Beim Friseur'
             ]),
             'name': fake.company(),
-            'weekday': fake.random_int(0, 6),
+            'weekday': random.choice(days),
             'location': location
         }
         depot, _ = Depot.objects.update_or_create(**depot_dict)
         return depot
 
-    def generate_subscription(self, main_member, co_member, depot, type):
+    def generate_subscription(self, main_member, co_member, depot, sub_types):
         sub_dict = {
             'depot': depot,
             'future_depot': None,
@@ -94,6 +97,8 @@ class Command(BaseCommand):
             member=co_member,
             join_date=sub_dict['creation_date'])
         subscription.save()
+        for sub_type in sub_types:
+            SubscriptionPart.objects.create(subscription=subscription, type=sub_type, activation_date=sub_dict['creation_date'])
         self.members.append(main_member)
         self.members.append(co_member)
 
@@ -110,7 +115,7 @@ class Command(BaseCommand):
             'ort': fake.city()
         }
 
-    def generate_depot_sub(self, depot, sub_shares, type):
+    def generate_depot_sub(self, depot, sub_shares, sub_types):
         props = self.get_random_props()
         mem1_fields = self.generate_member_dict(props)
         main_member = Member.objects.create(**mem1_fields)
@@ -118,41 +123,48 @@ class Command(BaseCommand):
         mem2_fields = self.generate_member_dict(props)
         co_member = Member.objects.create(**mem2_fields)
         self.generate_shares(main_member, sub_shares)
-        self.generate_subscription(main_member, co_member, depot, type)
+        self.generate_subscription(main_member, co_member, depot, sub_types)
 
     def add_arguments(self, parser):
-        parser.add_argument('--sub-size', type=int, help='Size of subscription', default=2)
+        parser.add_argument('--products', type=str, help='Products to use', default=["Gemüse"], nargs="+")
+        parser.add_argument('--sub-size', type=int, help='Size of subscription', default=[1], nargs="+")
         parser.add_argument('--sub-shares', type=int, help='Required shares per subscription', default=2)
         parser.add_argument('--sub-assignments', type=int, help='Required assignment per subscription', default=6)
-        parser.add_argument('--sub-prize', type=int, help='Proce of suscription', default=250)
+        parser.add_argument('--sub-price', type=int, help='Price of suscription', default=250)
         parser.add_argument('--depots', type=int, help='Number of depots to generate', default=4)
+        parser.add_argument('--days', type=int, help='Days for depots', default=list(range(7)), nargs="+")
         parser.add_argument('--subs-per-depot', type=int, help='Subscriptions per depot', default=10)
         parser.add_argument('--job-amount', type=int, help='Jobs per area', default=10)
 
     # entry point used by manage.py
     def handle(self, *args, **options):
-        subprod_field = {'name': 'Gemüse'}
-        sub_product, created = SubscriptionProduct.objects.get_or_create(**subprod_field)
+        sub_types = []
+        for product, size in itertools.zip_longest(options['products'], options['sub_size']):
+            size = size or 1
 
-        subsize_fields = {'name': 'Normales Abo', 'long_name': 'Ganz Normales Abo', 'units': options['sub_size'],
-                          'depot_list': True,
-                          'description': 'Das einzige abo welches wir haben, bietet genug Gemüse für einen Zwei personen Haushalt für eine Woche.',
-                          'product': sub_product}
-        size, _ = SubscriptionSize.objects.get_or_create(**subsize_fields)
+            subprod_field = {'name': product}
+            sub_product, created = SubscriptionProduct.objects.get_or_create(**subprod_field)
+            print("generated", sub_product.name)
+            subsize_fields = {'name': random.choice(['Tasche', 'Portion', '500g']), 'units': size,
+                            'depot_list': True,
+                            'description': 'Das einzige abo welches wir haben, bietet genug Gemüse für einen Zwei personen Haushalt für eine Woche.',
+                            'product': sub_product}
+            size, _ = SubscriptionSize.objects.get_or_create(**subsize_fields)
 
-        subtype_fields = {
-            'name': 'Normales Abo typ',
-            'long_name': '',
-            'shares': options['sub_shares'],
-            'required_assignments': options['sub_assignments'],
-            'price': options['sub_prize'],
-            'description': '',
-            'size': size
-        }
-        type, _ = SubscriptionType.objects.get_or_create(
-            name=subtype_fields['name'],
-            defaults=subtype_fields
-        )
+            subtype_fields = {
+                'name': 'Abo {}'.format(product),
+                'long_name': 'Ganz Normales {} Abo'.format(product),
+                'shares': options['sub_shares'],
+                'required_assignments': options['sub_assignments'],
+                'price': options['sub_price'],
+                'description': '',
+                'size': size
+            }
+            sub_type, _ = SubscriptionType.objects.get_or_create(
+                name=subtype_fields['name'],
+                defaults=subtype_fields
+            )
+            sub_types.append(sub_type)
 
         for i in range(0, options['depots']):
             props = self.get_random_props()
@@ -160,13 +172,15 @@ class Command(BaseCommand):
             mem1_fields = self.generate_member_dict(props)
             main_member = Member.objects.create(**mem1_fields)
             self.generate_shares(main_member, options['sub_shares'])
-            depot = self.generate_depot(props, main_member, i)
+            depot = self.generate_depot(props, main_member, i, options["days"])
             mem2_fields = self.generate_member_dict(props)
             co_member = Member.objects.create(**mem2_fields)
             self.generate_shares(co_member, options['sub_shares'])
-            self.generate_subscription(main_member, co_member, depot, type)
+            self.generate_subscription(main_member, co_member, depot, sub_types)
             for _ in range(1, options['subs_per_depot']):
-                self.generate_depot_sub(depot, options['sub_shares'], type)
+                random_sub_types = random.choices(sub_types, k=(len(sub_types)+1)//2)
+                print("generate random abos", ", ".join([st.name for st in random_sub_types]))
+                self.generate_depot_sub(depot, options['sub_shares'], random_sub_types)
 
         area1_fields = {'name': 'Ernten', 'description': 'Das Gemüse aus der Erde Ziehen', 'core': True,
                         'hidden': False, 'coordinator': self.members[0],


### PR DESCRIPTION
An example of how to run it:
python manage.py generate_testdata_advanced --depots 18 --product Gemüse/1 Obst/1,2 Brot Eier Tofu --days 2 4

will create Gemüse with size 1, Obst with size 1 and size 2, etc

Replaces the pull request #655 
