### PR TITLE
fix: make mass job copy work if USE_TZ=False

### DIFF
--- a/juntagrico/admins/forms/job_copy_form.py
+++ b/juntagrico/admins/forms/job_copy_form.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django import forms
+from django.conf import settings
 from django.contrib import admin
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -45,7 +46,7 @@ class JobCopyForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super().clean()
         if self.cleaned(cleaned_data) and not self.get_datetimes(cleaned_data):
-            raise ValidationError(_('Kein neuer Job fällt zwischen Anfangs- und Enddatum'))
+            raise ValidationError(_('Kein neuer Job fällt zwischen Anfangs- und Enddatum'), code='no_job_in_range')
         return cleaned_data
 
     def save(self, commit=True):
@@ -84,7 +85,7 @@ class JobCopyForm(forms.ModelForm):
             if date.isoweekday() not in weekdays:
                 continue
             dt = datetime.datetime.combine(date, time)
-            if is_naive(dt):
+            if settings.USE_TZ and is_naive(dt):
                 dt = dt.astimezone(gdtz())
             res.append(dt)
         return res
@@ -94,5 +95,5 @@ class JobCopyToFutureForm(JobCopyForm):
     def clean(self):
         cleaned_data = super().clean()
         if self.cleaned(cleaned_data) and self.get_datetimes(cleaned_data)[0] <= timezone.now():
-            raise ValidationError(_('Neue Jobs können nicht in der Vergangenheit liegen.'))
+            raise ValidationError(_('Neue Jobs können nicht in der Vergangenheit liegen.'), code='date_in_past')
         return cleaned_data

--- a/test/test_adminforms.py
+++ b/test/test_adminforms.py
@@ -1,9 +1,10 @@
 import datetime
 
 from django.core.exceptions import ValidationError
+from django.test import override_settings
 
 from juntagrico.admins.forms.delivery_copy_form import DeliveryCopyForm
-from juntagrico.admins.forms.job_copy_form import JobCopyForm
+from juntagrico.admins.forms.job_copy_form import JobCopyForm, JobCopyToFutureForm
 from juntagrico.admins.forms.location_replace_form import LocationReplaceForm
 from juntagrico.entity.delivery import Delivery
 from juntagrico.entity.jobs import RecuringJob
@@ -11,7 +12,7 @@ from juntagrico.entity.location import Location
 from test.util.test import JuntagricoTestCase
 
 
-class AdminTests(JuntagricoTestCase):
+class JobFormTests(JuntagricoTestCase):
 
     def testCopyJobForm(self):
         initial_count = RecuringJob.objects.all().count()
@@ -26,6 +27,7 @@ class AdminTests(JuntagricoTestCase):
         form = JobCopyForm(instance=self.job1, data=data)
         form.full_clean()
         with self.assertRaises(ValidationError):
+            # should raise, because no jobs are created in this date range
             form.clean()
         self.job1.time = datetime.datetime.now()
         data = {'type': self.job1.type.pk,
@@ -55,6 +57,47 @@ class AdminTests(JuntagricoTestCase):
         form.save()
         self.assertEqual(RecuringJob.objects.all().count(), initial_count + 2)
 
+    def testCopyJobToFutureForm(self):
+        # test failing case
+        initial_count = RecuringJob.objects.all().count()
+        data = {'type': self.job1.type.pk,
+                'time': '05:04:53',
+                'slots': '2',
+                'weekdays': ['1'],
+                'start_date': '01.07.2020',
+                'end_date': '07.07.2020',
+                'weekly': '7'
+                }
+        form = JobCopyToFutureForm(instance=self.job1, data=data)
+        form.full_clean()
+        with self.assertRaises(ValidationError) as validation_error:
+            # should raise, because jobs are in the past
+            form.clean()
+        self.assertEqual(validation_error.exception.code, 'date_in_past')
+
+        today = datetime.date.today()
+        # test successful case
+        data = {'type': self.job1.type.pk,
+                'time': '05:04:53',
+                'slots': '2',
+                'weekdays': ['1'],
+                'start_date': today + datetime.timedelta(1),
+                'end_date': today + datetime.timedelta(7),
+                'weekly': '7'
+                }
+        form = JobCopyToFutureForm(instance=self.job1, data=data)
+        form.full_clean()
+        form.clean()
+        form.save()
+        self.assertEqual(RecuringJob.objects.all().count(), initial_count + 1)
+
+
+@override_settings(USE_TZ=False)
+class JobFormWoTimezoneTests(JobFormTests):
+    pass
+
+
+class AdminTests(JuntagricoTestCase):
     def testDeliveryCopyForm(self):
         initial_count = Delivery.objects.all().count()
         data = {'subscription_size': self.sub_size.pk,


### PR DESCRIPTION
(cherry picked from commit 314c836ad14b58de5ef04482a17aed6ecd794b08)

# Description
If USE_TZ is False in the setting the datetime is now kept naive

# Further Ideas
All test cases should use [setUpTestData](https://docs.djangoproject.com/en/4.2/topics/testing/tools/#django.test.TestCase.setUpTestData) instead of setUp, as it is faster in most cases.
