### PR TITLE
member: Flexible required minimum shares amount on registration #623

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -363,6 +363,22 @@ ENABLE_SHARES
 
     True
 
+REQUIRED_SHARES
+^^^^^^^^^^^^^
+    .. note::
+    Added in version 1.7.0.
+
+  Specifies the minimum amount of shares that the main member must order during registration
+  regardless of the subscription requirements.
+
+  Type: Integer
+
+  default value
+
+  .. code-block:: python
+
+    1
+
 SHARE_PRICE
 ^^^^^^^^^^^
   Price of one share

--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -89,6 +89,7 @@ class Config:
     extra_sub_info = _get_setting('EXTRA_SUB_INFO')
     activity_area_info = _get_setting('ACTIVITY_AREA_INFO')
     enable_shares = _get_setting('ENABLE_SHARES', True)
+    required_shares = _get_setting('REQUIRED_SHARES', 1)
     enable_registration = _get_setting('ENABLE_REGISTRATION', True)
     base_fee = _get_setting('BASE_FEE')
     currency = _get_setting('CURRENCY', 'CHF')

--- a/juntagrico/templates/createsubscription/select_shares.html
+++ b/juntagrico/templates/createsubscription/select_shares.html
@@ -13,6 +13,7 @@
 {% block allcontent %}
     {% config "currency" as c_currency %}
     {% config "share_price" as c_share_price %}
+    {% config "required_shares" as c_required_shares %}
     {% enriched_organisation "D" as v_d_enriched_organisation %}
     {% vocabulary "share_pl" as v_share_pl %}
     {% vocabulary "subscription" as v_subscription %}
@@ -38,20 +39,19 @@
                 Beim Austritt aus {{ v_d_enriched_organisation }} bekommst du deine {{ v_share_pl }}
                 zurückerstattet.
                 {% endblocktrans %}
-                {% if shares.total_required > 0 %}
+                {% if shares.total_required > c_required_shares %}
                     {% blocktrans trimmed with shares.total_required as st %}
                     Für die von dir ausgewählten {{ v_subscription }}-Bestandteile brauchst du insgesamt {{ st }}
                     {{ v_share_pl }}. Du kannst natürlich noch mehr erwerben.
                     {% endblocktrans %}
                     <br/>
-                {% else %}
+                {% elif c_required_shares > 0 %}
                     {% blocktrans trimmed %}
-                    Als {{ v_member_type }} ohne {{ v_subscription }} benötigst du 1
-                    {{ v_share }}. Du kannst natürlich noch mehr erwerben.
+                    Du benötigst mindestens {{ c_required_shares }} {{ v_share_pl }}. Du kannst natürlich noch mehr erwerben.
                     {% endblocktrans %}
                     <br/>
                 {% endif %}
-                {% if co_members|length > 0 %}
+                {% if co_members|length > 0 and shares.remaining_required > 0 %}
                     {% blocktrans trimmed with shares.remaining_required as sr %}
                     Teile die restlichen benötigten {{ sr }} {{ v_share_pl }} unter dir und
                     deinen {{ v_co_member_pl }} auf.
@@ -66,14 +66,21 @@
                     {% blocktrans %}Neue {{ v_share_pl }}{% endblocktrans %}:
                 </label>
                 <div class="col-md-3">
-                    <input type="number" name="shares_mainmember" class="form-control" value="{{ member.new_shares|default:shares.total_required }}" min="{% if shares.existing_main_member == 0 %}1{% else %}0{% endif %}"/>
+                    <input type="number" name="shares_mainmember" class="form-control" value="{{ member.new_shares|default:shares.total_required }}" 
+                           min="{{ shares.remaining_required_main_member }}"/>
                 </div>
                 <label class="col-md-6 col-form-label">
-                    {% if shares.existing_main_member == 0 %}
-                        {% blocktrans trimmed %}
-                        Du brauchst als HauptbezieherIn mindestens 1 {{ v_share }}.
-                        {% endblocktrans %}
-                    {% else %}
+                    {% if shares.existing_main_member < c_required_shares %}
+                        {% if c_required_shares == 1 %}
+                            {% blocktrans trimmed %}
+                            Du brauchst als HauptbezieherIn mindestens {{ c_required_shares }} {{ v_share }}.
+                            {% endblocktrans %}
+                        {% elif c_required_shares > 1 %}
+                            {% blocktrans trimmed %}
+                            Du brauchst als HauptbezieherIn mindestens {{ c_required_shares }} {{ v_share_pl }}.
+                            {% endblocktrans %}
+                        {% endif %}
+                    {% elif shares.existing_main_member > 0 %}
                         {% blocktrans trimmed with msc=member.active_shares_count%}
                         Du hast bereits {{ msc }} {{ v_share_pl }}
                         {% endblocktrans %}

--- a/juntagrico/util/sessions.py
+++ b/juntagrico/util/sessions.py
@@ -111,10 +111,13 @@ class CSSessionObject(SessionObject):
         shares = {
             'existing_main_member': self.main_member.usable_shares_count,
             'existing_co_member': sum([co_member.usable_shares_count for co_member in self.co_members]),
-            'total_required': max(self.required_shares(), 1)
+            'total_required': max(self.required_shares(), Config.required_shares())
         }
         shares['remaining_required'] = max(
             0, shares['total_required'] - max(0, shares['existing_main_member'] + shares['existing_co_member'])
+        )
+        shares['remaining_required_main_member'] = max(
+            0, Config.required_shares() - shares['existing_main_member']
         )
         return shares
 
@@ -126,7 +129,7 @@ class CSSessionObject(SessionObject):
         new_main_member = getattr(self.main_member, 'new_shares', 0)
         new_co_members = self.get_co_member_shares()
         # evaluate
-        return shares['existing_main_member'] + new_main_member > 0\
+        return shares['existing_main_member'] + new_main_member >= Config.required_shares()\
             and new_main_member + new_co_members >= shares['remaining_required']
 
     def next_page(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 200


### PR DESCRIPTION
# Description
implements #623 partially

# TODO

- [ ] Now share order page is not shown if 0 shares are required. Consider option to show it also in that case.

# Release Notes
New Setting `REQURIED_SHARES`, specifies how many shares must be ordered during registration. Defaults to 1 to match previous behaviour
