### PR TITLE
fix: copy all relevant fields in job mass copy

### DIFF
--- a/juntagrico/admins/forms/job_copy_form.py
+++ b/juntagrico/admins/forms/job_copy_form.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.timezone import get_default_timezone as gdtz, localtime, is_naive
 from django.utils.translation import gettext as _
+from djrichtextfield.widgets import RichTextWidget
 
 from juntagrico.entity.jobs import RecuringJob
 from juntagrico.util.temporal import weekday_choices
@@ -15,7 +16,7 @@ from juntagrico.util.temporal import weekday_choices
 class JobCopyForm(forms.ModelForm):
     class Meta:
         model = RecuringJob
-        fields = ['type', 'slots', 'infinite_slots', 'multiplier']
+        fields = ['type', 'slots', 'infinite_slots', 'multiplier', 'additional_description', 'duration_override']
 
     weekdays = forms.MultipleChoiceField(label=_('Wochentage'), choices=weekday_choices,
                                          widget=forms.widgets.CheckboxSelectMultiple)
@@ -43,6 +44,11 @@ class JobCopyForm(forms.ModelForm):
             self.fields['time'].initial = localtime(inst.time)
         self.fields['weekdays'].initial = [inst.time.isoweekday()]
 
+        if 'djrichtextfield' in settings.INSTALLED_APPS and hasattr(settings, 'DJRICHTEXTFIELD_CONFIG'):
+            self.fields['additional_description'].widget = RichTextWidget()
+
+        self.new_jobs = []
+
     def clean(self):
         cleaned_data = super().clean()
         if self.cleaned(cleaned_data) and not self.get_datetimes(cleaned_data):
@@ -54,16 +60,37 @@ class JobCopyForm(forms.ModelForm):
 
         newjob = None
         for dt in self.get_datetimes(self.cleaned_data):
-            newjob = RecuringJob.objects.create(
-                type=inst.type, slots=inst.slots, infinite_slots=inst.infinite_slots,
-                multiplier=inst.multiplier, time=dt
+            newjob = RecuringJob(
+                type=inst.type,
+                slots=inst.slots,
+                infinite_slots=inst.infinite_slots,
+                time=dt,
+                multiplier=inst.multiplier,
+                additional_description=inst.additional_description,
+                duration_override=inst.duration_override,
             )
-            newjob.save()
+            if commit:
+                newjob.save()
+            self.new_jobs.append(newjob)
         return newjob
 
-    def save_m2m(self):
-        # HACK: the admin expects this method to exist
-        pass
+    def save_related(self, formsets=None):
+        # collect contacts from formsets
+        contacts = []
+        if formsets:
+            for contact_form in formsets[0].forms:
+                if not contact_form.cleaned_data['DELETE']:
+                    contacts.append(contact_form.instance.copy())
+            # excepted by ModelAdmin
+            formsets[0].new_objects = []
+            formsets[0].changed_objects = []
+            formsets[0].deleted_objects = []
+        # save and apply contacts
+        for job in self.new_jobs:
+            job.save()
+            for contact in contacts:
+                job.contact_set.add(contact, bulk=False)
+
 
     @staticmethod
     def cleaned(cleaned_data):

--- a/juntagrico/admins/forms/job_copy_form.py
+++ b/juntagrico/admins/forms/job_copy_form.py
@@ -74,10 +74,10 @@ class JobCopyForm(forms.ModelForm):
             self.new_jobs.append(newjob)
         return newjob
 
-    def save_related(self, formsets=None):
+    def save_related(self, formsets):
         # collect contacts from formsets
         contacts = []
-        if formsets:
+        if formsets and len(formsets) >= 1:
             for contact_form in formsets[0].forms:
                 if not contact_form.cleaned_data['DELETE']:
                     contacts.append(contact_form.instance.copy())

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -57,13 +57,19 @@ class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTe
 
     def get_inlines(self, request, obj):
         if self.is_copy_view(request):
-            return []  # special case for mass job copy action
+            return [ContactInline]  # special case for mass job copy action
         return super().get_inlines(request, obj)
+
+    def save_related(self, request, form, formsets, change):
+        if self.is_copy_view(request):
+            form.save_related(formsets)
+        else:
+            super().save_related(request, form, formsets, change)
 
     @admin.action(description=_('Job mehrfach kopieren...'))
     @single_element_action('Genau 1 Job auswählen!')
     def mass_copy_job(self, request, queryset):
-        inst, = queryset.all()
+        inst = queryset.first()
         return HttpResponseRedirect(reverse('admin:action-mass-copy-job', args=[inst.id]))
 
     @admin.action(description=_('Jobs kopieren'))

--- a/juntagrico/entity/contact.py
+++ b/juntagrico/entity/contact.py
@@ -90,6 +90,9 @@ class MemberContact(Contact):
             inner_html += '<span class="contact-member-phone">{}</span>\n'.format(self.member.phone)
         return inner_html
 
+    def copy(self):
+        return MemberContact(member=self.member, display=self.display)
+
     class Meta:
         verbose_name = Config.vocabulary('member')
         verbose_name_plural = Config.vocabulary('member_pl')
@@ -103,6 +106,9 @@ class EmailContact(Contact):
 
     def _inner_html(self):
         return '<a href="mailto:{0}">{0}</a>'.format(self.email)
+
+    def copy(self):
+        return EmailContact(email=self.email)
 
     class Meta:
         verbose_name = _('E-Mail-Adresse')
@@ -118,6 +124,9 @@ class PhoneContact(Contact):
     def _inner_html(self):
         return self.phone
 
+    def copy(self):
+        return PhoneContact(phone=self.phone)
+
     class Meta:
         verbose_name = _('Telefonnummer')
         verbose_name_plural = _('Telefonnummer')
@@ -131,6 +140,9 @@ class TextContact(Contact):
 
     def _inner_html(self):
         return urlize(self.text)
+
+    def copy(self):
+        return TextContact(text=self.text)
 
     class Meta:
         verbose_name = _('Freier Kontaktbeschrieb')

--- a/juntagrico/tests/test_admin.py
+++ b/juntagrico/tests/test_admin.py
@@ -31,16 +31,6 @@ class AdminTests(JuntagricoTestCase):
         response = self.assertPost(url, data={'action': 'mass_copy_job', '_selected_action': selected_items},
                                    member=self.admin, code=302)
         self.assertGet(response.url, member=self.admin)
-        self.assertPost(response.url,
-                        data={'type': self.job1.type.pk,
-                              'slots': self.job1.slots,
-                              'multiplier': self.job1.multiplier,
-                              'time': '12:00',
-                              'start_date': '22.01.2022',
-                              'end_date': '30.01.2022',
-                              'weekdays': ['1'],
-                              'weekly': '7'},
-                        member=self.admin, code=302)
         selected_items = [self.job1.pk, self.job2.pk]
         self.assertPost(url, data={'action': 'mass_copy_job', '_selected_action': selected_items}, member=self.admin,
                         code=302)

--- a/juntagrico/tests/test_adminforms.py
+++ b/juntagrico/tests/test_adminforms.py
@@ -12,7 +12,7 @@ from juntagrico.entity.delivery import Delivery
 from juntagrico.entity.jobs import RecuringJob
 from juntagrico.entity.location import Location
 from . import JuntagricoTestCase
-from ..entity.contact import EmailContact, MemberContact, PhoneContact
+from ..entity.contact import EmailContact, MemberContact
 
 
 class JobFormTests(JuntagricoTestCase):
@@ -67,7 +67,6 @@ class JobFormTests(JuntagricoTestCase):
         form.full_clean()
         form.clean()
         form.save()
-        form.save_related()
         self.assertEqual(RecuringJob.objects.all().count(), initial_count + 1)
         # check completeness of copy
         new_job = RecuringJob.objects.last()
@@ -90,7 +89,6 @@ class JobFormTests(JuntagricoTestCase):
         form = JobCopyForm(instance=self.job1, data=data)
         form.full_clean()
         form.save()
-        form.save_related()
         self.assertEqual(RecuringJob.objects.all().count(), initial_count + 2)
 
     def testCopyJobFormFull(self):
@@ -185,7 +183,6 @@ class JobFormTests(JuntagricoTestCase):
         form.full_clean()
         form.clean()
         form.save()
-        form.save_related()
         self.assertEqual(RecuringJob.objects.all().count(), initial_count + 1)
 
 

--- a/juntagrico/tests/test_adminforms.py
+++ b/juntagrico/tests/test_adminforms.py
@@ -2,6 +2,8 @@ import datetime
 
 from django.core.exceptions import ValidationError
 from django.test import override_settings
+from django.urls import reverse
+from django.utils import timezone
 
 from juntagrico.admins.forms.delivery_copy_form import DeliveryCopyForm
 from juntagrico.admins.forms.job_copy_form import JobCopyForm, JobCopyToFutureForm
@@ -10,11 +12,32 @@ from juntagrico.entity.delivery import Delivery
 from juntagrico.entity.jobs import RecuringJob
 from juntagrico.entity.location import Location
 from . import JuntagricoTestCase
+from ..entity.contact import EmailContact, MemberContact, PhoneContact
 
 
 class JobFormTests(JuntagricoTestCase):
 
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        time = timezone.now() + timezone.timedelta(hours=2)
+        cls.complex_job_data = {
+            'slots': 1,
+            'time': time,
+            'type': cls.job_type,
+            'infinite_slots': True,
+            'multiplier': 2,
+            'additional_description': 'Extra Description',
+            'duration_override': 6
+        }
+        cls.complex_job = RecuringJob.objects.create(**cls.complex_job_data)
+        cls.email_contact = EmailContact(email='test@test.org')
+        cls.member_contact = MemberContact(member=cls.member2, display=MemberContact.DISPLAY_EMAIL)
+        cls.complex_job.contact_set.add(cls.email_contact, bulk=False)
+        cls.complex_job.contact_set.add(cls.member_contact, bulk=False)
+
     def testCopyJobForm(self):
+        # test 0 copies (fails)
         initial_count = RecuringJob.objects.all().count()
         data = {'type': self.job1.type.pk,
                 'time': '05:04:53',
@@ -29,8 +52,10 @@ class JobFormTests(JuntagricoTestCase):
         with self.assertRaises(ValidationError):
             # should raise, because no jobs are created in this date range
             form.clean()
-        self.job1.time = datetime.datetime.now()
-        data = {'type': self.job1.type.pk,
+
+        # test 1 copy
+        self.complex_job.time = datetime.datetime.now()
+        data = {'type': self.complex_job.type.pk,
                 'time': '05:04:53',
                 'slots': '2',
                 'weekdays': ['1'],
@@ -38,12 +63,22 @@ class JobFormTests(JuntagricoTestCase):
                 'end_date': '07.07.2020',
                 'weekly': '7'
                 }
-        form = JobCopyForm(instance=self.job1, data=data)
+        form = JobCopyForm(instance=self.complex_job, data=data)
         form.full_clean()
         form.clean()
-        form.save_m2m()
         form.save()
+        form.save_related()
         self.assertEqual(RecuringJob.objects.all().count(), initial_count + 1)
+        # check completeness of copy
+        new_job = RecuringJob.objects.last()
+        self.assertEqual(self.complex_job.type, new_job.type)
+        self.assertEqual(self.complex_job.slots, new_job.slots)
+        self.assertEqual(self.complex_job.infinite_slots, new_job.infinite_slots)
+        self.assertEqual(data['time'], timezone.localtime(new_job.time).strftime('%H:%M:%S'))
+        self.assertEqual(self.complex_job.multiplier, new_job.multiplier)
+        self.assertEqual(self.complex_job.additional_description, new_job.additional_description)
+        self.assertEqual(self.complex_job.duration_override, new_job.duration_override)
+        # Test 2 copies
         data = {'type': self.job1.type.pk,
                 'time': '05:04:53',
                 'slots': '2',
@@ -55,7 +90,68 @@ class JobFormTests(JuntagricoTestCase):
         form = JobCopyForm(instance=self.job1, data=data)
         form.full_clean()
         form.save()
+        form.save_related()
         self.assertEqual(RecuringJob.objects.all().count(), initial_count + 2)
+
+    def testCopyJobFormFull(self):
+        self.assertGet(reverse('admin:action-mass-copy-job', args=(self.complex_job.pk,)), member=self.admin)
+        # test mass job copy changing entries
+        data = {
+            "type": str(self.complex_job.type.pk),
+            "slots": "2",
+            "multiplier": "3.0",
+            "additional_description": "New Description",
+            "duration_override": "9",
+            "weekdays": "2",
+            "time": "13:46:46",
+            "start_date": "18.06.2024",
+            "end_date": "19.06.2024",
+            "weekly": "7",
+            "juntagrico-contact-content_type-object_id-TOTAL_FORMS": "3",
+            "juntagrico-contact-content_type-object_id-INITIAL_FORMS": "2",
+            "juntagrico-contact-content_type-object_id-MIN_NUM_FORMS": "0",
+            "juntagrico-contact-content_type-object_id-MAX_NUM_FORMS": "1000",
+            "juntagrico-contact-content_type-object_id-0-DELETE": "on",
+            "juntagrico-contact-content_type-object_id-0-email": "test@test.org",
+            "juntagrico-contact-content_type-object_id-0-sort_order": "0",
+            "juntagrico-contact-content_type-object_id-0-id": str(self.email_contact.id),
+            "juntagrico-contact-content_type-object_id-0-polymorphic_ctype":
+                str(self.email_contact.polymorphic_ctype_id),
+            "juntagrico-contact-content_type-object_id-1-member": str(self.member.pk),
+            "juntagrico-contact-content_type-object_id-1-display": "B",
+            "juntagrico-contact-content_type-object_id-1-sort_order": "0",
+            "juntagrico-contact-content_type-object_id-1-id": str(self.member_contact.id),
+            "juntagrico-contact-content_type-object_id-1-polymorphic_ctype":
+                str(self.member_contact.polymorphic_ctype_id),
+            "juntagrico-contact-content_type-object_id-2-email": "test2@test.org",
+            "juntagrico-contact-content_type-object_id-2-sort_order": "0",
+            "juntagrico-contact-content_type-object_id-2-id": "",
+            "juntagrico-contact-content_type-object_id-2-polymorphic_ctype":
+                str(self.email_contact.polymorphic_ctype_id),
+        }
+        self.assertPost(reverse('admin:action-mass-copy-job', args=(self.complex_job.pk,)),
+                        data=data, code=302, member=self.admin)
+        self.complex_job.refresh_from_db()
+        # check that original job is unchanged
+        self.assertEqual(self.complex_job.type, self.complex_job_data['type'])
+        self.assertEqual(self.complex_job.slots, self.complex_job_data['slots'])
+        self.assertEqual(self.complex_job.infinite_slots, self.complex_job_data['infinite_slots'])
+        self.assertEqual(self.complex_job.time, self.complex_job_data['time'])
+        self.assertEqual(self.complex_job.multiplier, self.complex_job_data['multiplier'])
+        self.assertEqual(self.complex_job.additional_description, self.complex_job_data['additional_description'])
+        self.assertEqual(self.complex_job.duration_override, self.complex_job_data['duration_override'])
+        self.assertListEqual(self.complex_job.get_emails(), ['test@test.org', self.member2.email])
+        # check completeness of copy
+        new_job = RecuringJob.objects.last()
+        self.assertEqual(new_job.type, self.complex_job.type)
+        self.assertEqual(new_job.slots, 2)
+        self.assertEqual(new_job.infinite_slots, False)
+        self.assertEqual(timezone.localtime(new_job.time).strftime('%H:%M:%S'), '13:46:46')
+        self.assertEqual(new_job.multiplier, 3.0)
+        self.assertEqual(new_job.additional_description, "New Description")
+        self.assertEqual(new_job.duration_override, 9)
+        self.assertListEqual(new_job.get_emails(), [self.member.email, 'test2@test.org'])
+
 
     def testCopyJobToFutureForm(self):
         # test failing case
@@ -89,6 +185,7 @@ class JobFormTests(JuntagricoTestCase):
         form.full_clean()
         form.clean()
         form.save()
+        form.save_related()
         self.assertEqual(RecuringJob.objects.all().count(), initial_count + 1)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 200


### PR DESCRIPTION
# Description
The additional description, duration override and contacts of a job were not copied to the new jobs in the mass copy function. The fields are not copied and can also be edited in the copy process.