### PR TITLE
fix: don't count future assignments #682

### DIFF
--- a/juntagrico/queryset/subscription.py
+++ b/juntagrico/queryset/subscription.py
@@ -140,8 +140,8 @@ class SubscriptionQuerySet(SimpleStateModelQuerySet, PolymorphicQuerySet):
         :return: the queryset of subscriptions with annotations `assignment_count`, `core_assignment_count`, `required_assignments`, `required_core_assignments`,
         `assignments_progress` and `core_assignments_progress`.
         :param prefix: prefix for the resulting attribute names `assignment_count`, `core_assignment_count`, `assignments_progress`, `core_assignments_progress`. default=''
-        :return: the queryset of subscriptions with annotations `assignments_progress`, `core_assignments_progress`, `assignments_progress`,
-        `core_assignments_progress`, `assignments_progress` and `core_assignments_progress`
+        :return: the queryset of subscriptions with annotations `assignments_progress`, `core_assignments_progress`, `required_assignments`,
+        `core_required_assignments`, `assignment_count` and `core_assignment_count`
         """
         return self.annotate_required_assignments(start, end).annotate_assignment_counts(
             start, count_jobs_until or end, of_member, prefix

--- a/juntagrico/templatetags/juntagrico/widgets.py
+++ b/juntagrico/templatetags/juntagrico/widgets.py
@@ -20,11 +20,14 @@ def assignment_data(request):
         return None
 
     # calculate assignments
+    today = datetime.date.today()
     sub = Subscription.objects.annotate_assignment_counts(
         of_member=member,
-        end=datetime.date.today(),
+        end=today,
         prefix='member_'
-    ).annotate_assignments_progress().get(pk=member.subscription_current)
+    ).annotate_assignments_progress(
+        end=today
+    ).get(pk=member.subscription_current)
     sub.remaining_assignments = max(
         sub.required_assignments - sub.assignment_count,
         sub.required_core_assignments - sub.core_assignment_count,


### PR DESCRIPTION
In the sidebar widget the future assignments were counted, but displayed wrong. Reverting to original behavior, where future assignments are not counted.

fixes #682