### PR TITLE
fix: ignore pre_saves for loaddata

### DIFF
--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -343,7 +343,8 @@ class Assignment(JuntagricoBaseModel):
 
     @classmethod
     def pre_save(cls, sender, instance, **kwargs):
-        instance.core_cache = instance.is_core()
+        if not kwargs.get('raw', False):
+            instance.core_cache = instance.is_core()
 
     def can_modify(self, request):
         return self.job.get_real_instance().can_modify(request)

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -215,11 +215,12 @@ class Member(JuntagricoBaseModel):
         '''
         Callback to create corresponding user when new member is created.
         '''
-        if getattr(instance, 'user', None) is None:
-            username = make_username(
-                instance.first_name, instance.last_name)
-            user, created = User.objects.get_or_create(username=username)
-            instance.user = user
+        if not kwds.get('raw', False):
+            if getattr(instance, 'user', None) is None:
+                username = make_username(
+                    instance.first_name, instance.last_name)
+                user, created = User.objects.get_or_create(username=username)
+                instance.user = user
 
     @classmethod
     def post_delete(cls, sender, instance, **kwds):

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -215,12 +215,10 @@ class Member(JuntagricoBaseModel):
         '''
         Callback to create corresponding user when new member is created.
         '''
-        if not kwds.get('raw', False):
-            if getattr(instance, 'user', None) is None:
-                username = make_username(
-                    instance.first_name, instance.last_name)
-                user, created = User.objects.get_or_create(username=username)
-                instance.user = user
+        if not kwds.get('raw', False) and getattr(instance, 'user', None) is None:
+            username = make_username(instance.first_name, instance.last_name)
+            user, created = User.objects.get_or_create(username=username)
+            instance.user = user
 
     @classmethod
     def post_delete(cls, sender, instance, **kwds):

--- a/juntagrico/lifecycle/sub.py
+++ b/juntagrico/lifecycle/sub.py
@@ -18,14 +18,15 @@ def sub_post_save(sender, instance, created, **kwargs):
 
 
 def sub_pre_save(sender, instance, **kwargs):
-    with transaction.atomic():
-        check_sub_reactivation(instance)
-        instance.check_date_order()
-        handle_activated_deactivated(instance, sender, sub_activated, sub_deactivated)
-        if instance._old['cancellation_date'] is None and instance.cancellation_date is not None:
-            sub_canceled.send(sender=sender, instance=instance)
-        check_children_dates(instance)
-        check_sub_primary(instance)
+    if not kwargs.get('raw', False):
+        with transaction.atomic():
+            check_sub_reactivation(instance)
+            instance.check_date_order()
+            handle_activated_deactivated(instance, sender, sub_activated, sub_deactivated)
+            if instance._old['cancellation_date'] is None and instance.cancellation_date is not None:
+                sub_canceled.send(sender=sender, instance=instance)
+            check_children_dates(instance)
+            check_sub_primary(instance)
 
 
 def handle_sub_activated(sender, instance, **kwargs):

--- a/juntagrico/lifecycle/submembership.py
+++ b/juntagrico/lifecycle/submembership.py
@@ -8,7 +8,8 @@ from juntagrico.config import Config
 
 
 def sub_membership_pre_save(sender, instance, **kwargs):
-    check_sub_membership_consistency(instance)
+    if not kwargs.get('raw', False):
+        check_sub_membership_consistency(instance)
 
 
 def check_submembership_dates(instance):

--- a/juntagrico/lifecycle/subpart.py
+++ b/juntagrico/lifecycle/subpart.py
@@ -24,5 +24,6 @@ def check_subpart_parent_dates(instance, subscription):
 
 
 def sub_part_pre_save(sender, instance, **kwargs):
-    check_sub_part_consistency(instance)
-    handle_activated_deactivated(instance, sender, sub_part_activated, sub_part_deactivated)
+    if not kwargs.get('raw', False):
+        check_sub_part_consistency(instance)
+        handle_activated_deactivated(instance, sender, sub_part_activated, sub_part_deactivated)


### PR DESCRIPTION
when using manage.py loaddata the presave signals are triggered but the actions should usually be ignored to avoid accessing objects that don't exist yet.