### PR TITLE
fix: subscription deactivation date visible to member in subscription overview

### DIFF
--- a/juntagrico/templates/juntagrico/my/subscription/snippets/banners/canceled.html
+++ b/juntagrico/templates/juntagrico/my/subscription/snippets/banners/canceled.html
@@ -9,7 +9,7 @@
     </div>
     {% if subscription.deactivation_date %}
         <div>
-            {% blocktrans with dd=subscription.cancellation_date %}
+            {% blocktrans with dd=subscription.deactivation_date %}
                 Deaktivierung erfolgt per {{ dd }}.
             {% endblocktrans %}
         </div>


### PR DESCRIPTION
# Description
The banner is falsely showing the cancellation date twice instead of the deactivation date.

![grafik](https://github.com/user-attachments/assets/eeb23a8e-e8f1-41b8-b4fa-de3bd1db97db)