### PR TITLE
fix: subscription deactivation via django admin

### DIFF
--- a/juntagrico/lifecycle/sub.py
+++ b/juntagrico/lifecycle/sub.py
@@ -114,7 +114,8 @@ def check_children_dates(instance):
                           ' 2. Aktivierungsdatum vom {0}').format(Config.vocabulary('subscription'))
     try:
         for part in instance.parts.all():
-            check_subpart_parent_dates(part, instance)
+            # empty end dates are made consistent on save, no need to check
+            check_subpart_parent_dates(part, instance, check_empty_end=False)
     except ValidationError as e:
         raise ValidationError(
             _(
@@ -122,7 +123,8 @@ def check_children_dates(instance):
             code='invalid') from e
     try:
         for membership in instance.subscriptionmembership_set.all():
-            check_submembership_parent_dates(membership)
+            # empty end dates are made consistent on save, no need to check
+            check_submembership_parent_dates(membership, check_empty_end=False)
     except ValidationError as e:
         raise ValidationError(
             _('Aktivierungs- oder Deaktivierungsdatum passt nicht zum untergeordneten Beitritts- oder Austrittsdatum.' + reactivation_info),

--- a/juntagrico/lifecycle/subpart.py
+++ b/juntagrico/lifecycle/subpart.py
@@ -6,21 +6,30 @@ from juntagrico.util.lifecycle import handle_activated_deactivated
 
 
 def check_sub_part_consistency(instance):
+    # keep part deactivation date consistent with subscription deactivation date
+    sub_deactivation_date = instance.subscription.deactivation_date
+    if sub_deactivation_date is not None and instance.deactivation_date is None:
+        instance.deactivation_date = sub_deactivation_date
+    # check consistency
     instance.check_date_order()
     check_subpart_parent_dates(instance, instance.subscription)
 
 
-def check_subpart_parent_dates(instance, subscription):
+def check_subpart_parent_dates(instance, subscription, check_empty_end=True):
     s_activated = subscription.activation_date is not None
     p_activated = instance.activation_date is not None
+    wrong_start = (p_activated and s_activated and subscription.activation_date > instance.activation_date) or (not s_activated and p_activated)
+    if wrong_start:
+        raise ValidationError(_('Aktivierungsdatum des Bestandteils passt nicht zum übergeordneten Aktivierungsdatum'), code='part_activation_date_mismatch')
     s_deactivated = subscription.deactivation_date is not None
     p_deactivated = instance.deactivation_date is not None
-    wrong_start = (p_activated and s_activated and subscription.activation_date > instance.activation_date) or (not s_activated and p_activated)
-    wrong_end = (p_deactivated and s_deactivated and subscription.deactivation_date < instance.activation_date) or (s_deactivated and not p_deactivated)
-    if wrong_start:
-        raise ValidationError(_('Aktivierungsdatum des Bestandteils passt nicht zum übergeordneten Aktivierungsdatum'), code='invalid')
+    wrong_end = (
+        p_deactivated and s_deactivated and subscription.deactivation_date < instance.activation_date
+    ) or (
+        check_empty_end and s_deactivated and not p_deactivated
+    )
     if wrong_end:
-        raise ValidationError(_('Deaktivierungsdatum des Bestandteils passt nicht zum übergeordneten Deaktivierungsdatum'), code='invalid')
+        raise ValidationError(_('Deaktivierungsdatum des Bestandteils passt nicht zum übergeordneten Deaktivierungsdatum'), code='part_deactivation_date_mismatch')
 
 
 def sub_part_pre_save(sender, instance, **kwargs):


### PR DESCRIPTION
# Description
Deactivation of subscriptions should be done via the cancellation lists. However some admins found a workaround to do deactivation via the django admin. This previously worked by first setting the deactivation date or the parts, then the leave dates on the subscription memberships and finally the deactivation date of the subscription.
Since juntagrico 1.6 the form checks if the last member leaves the subscription and raises a validation error as the subscription would be inconsistent in that case. Thus the above approach for deactivation stopped working for them.
This fix, enables the deactivation of the subscription in the django admin, by setting the deactivation date of the subscription. The date will be propagated to empty leave dates and part deactivation dates. Deactivation also works if all dates are set consistently and saved in one submit.

# Long term
#646 is aiming to reduce the complexity of consistency checks and make the issue described above obsolete.