### PR TITLE
member: Display accurate info on changed depot

### DIFF
--- a/juntagrico/templates/depot_change.html
+++ b/juntagrico/templates/depot_change.html
@@ -15,17 +15,13 @@
     {% vocabulary "depot" as v_depot %}
     {% vocabulary "subscription" as v_subscription %}
     {% if saved %}
-        <div class="alert alert-success">
-            {% if subscription.waiting %}
+        {% if subscription.waiting %}
+            <div class="alert alert-success">
                 {% blocktrans %}Dein/e {{ v_depot }} wurde geändert.{% endblocktrans %}
-            {% else %}
-                {% blocktrans trimmed with spe=subscription.primary_member.email sde=subscription.depot.name%}
-                !!!Achtung! Dein/e {{ v_depot }} änderst erst bei der nächsten {{ v_depot }}-Listen Generierung.
-                Solange keine Email an {{ spe }}
-                mit der Bestätigung für dein/e/n neue/s/n {{ v_depot }} gesendet wurde ist noch dein/e/n alte/s/n {{ v_depot }}
-                {{ sde }} aktiv!!!
-                {% endblocktrans %}
-            {% endif %}
+        {% else %}
+            <div class="alert alert-warning">
+                {% include "juntagrico/my/depot/snippets/change_pending_info.html" %}
+        {% endif %}
             <br/>
             <a href="{% url 'subscription-single' subscription.id %}">
                 {% blocktrans %}Zurück zur {{ v_subscription }}-Übersicht{% endblocktrans %}
@@ -60,10 +56,7 @@
                 </div>
             </div>
             <div class="offset-md-3 form-actions">
-                {% blocktrans trimmed %}
-                Achtung! Dein/e {{ v_depot }} änderst erst bei der nächsten {{ v_depot }}listen Generierung. Du wirst
-                darüber informiert wenn dein/e {{ v_depot }} ändert.
-                {% endblocktrans %}
+                {% include "juntagrico/my/depot/snippets/change_pending_info.html" %}
                 <br/>
                 <br/>
                 <button type="submit" class="btn btn-success">

--- a/juntagrico/templates/juntagrico/my/depot/snippets/change_pending_info.html
+++ b/juntagrico/templates/juntagrico/my/depot/snippets/change_pending_info.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% blocktrans trimmed with spe=subscription.primary_member.email sde=subscription.depot.name sfe=subscription.future_depot.name%}
+<strong>Achtung:</strong> Deine Änderung zur/m {{ v_depot }} "{{ sfe }}" wurde beantragt.
+    Wir informieren dich per E-Mail an {{ spe }} sobald die Änderung aktiv wird.
+    Bis dahin ist dein/e Depot weiterhin <strong>"{{ sde }}"</strong>.
+{% endblocktrans %}

--- a/juntagrico/templates/juntagrico/my/depot/snippets/depot_summary.html
+++ b/juntagrico/templates/juntagrico/my/depot/snippets/depot_summary.html
@@ -1,6 +1,11 @@
 {% load juntagrico.config %}
 {% load i18n %}
 {% vocabulary "depot" as v_depot %}
+{% if subscription.future_depot %}
+    <div class="alert alert-warning">
+        {% include "juntagrico/my/depot/snippets/change_pending_info.html" %}
+    </div>
+{% endif %}
 <a href="{% url 'depot' subscription.depot.id %}">
     {{ subscription.depot.name }}
 </a>


### PR DESCRIPTION
# Description
display info in overview when depot change is pending and formulate info after change more accurately

![grafik](https://github.com/user-attachments/assets/63831501-f970-4811-bbcb-4c096c0a9fdd)

The same message is shown after changing the depot. Previously after changing a depot the message said, that activation would happen after depot list generation. As list generation may happen without updating depots (especially since #574), this is inaccurate and was probably cryptic to the member anyway.

