### PR TITLE
fix: Don't send password reset emails to inactive members #318

### DIFF
--- a/juntagrico/tests/test_profile.py
+++ b/juntagrico/tests/test_profile.py
@@ -135,6 +135,13 @@ class ProfileTests(JuntagricoTestCase):
             member.refresh_from_db()
             self.assertEqual(member.inactive, result, f'{member} {member.email}')
 
+
+class AuthTests(JuntagricoTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.deactivated_member = cls.create_member('deactivated_member@example.com', deactivation_date='2020-01-01')
+
     def testConfirmEmail(self):
         self.assertGet(reverse('send-confirm'))
         self.assertEqual(len(mail.outbox), 1)
@@ -151,8 +158,12 @@ class ProfileTests(JuntagricoTestCase):
         self.assertEqual(len(mail.outbox), 0)
 
     def testNewPasswordPost(self):
-        self.assertPost(reverse('password_reset'), {'email': 'member_without_shares@email.org'}, code=302)
+        self.assertPost(reverse('password_reset'), {'email': 'email1@email.org'}, code=302)
         self.assertEqual(len(mail.outbox), 1)
+
+    def testDeactivatedMemberNewPasswordPost(self):
+        self.assertPost(reverse('password_reset'), {'email': 'deactivated_member@example.com'}, code=302)
+        self.assertEqual(len(mail.outbox), 0)  # should send no email
 
     def testLogout(self):
         self.assertGet(reverse('logout'), code=302)

--- a/juntagrico/tests/test_subs.py
+++ b/juntagrico/tests/test_subs.py
@@ -53,7 +53,7 @@ class SubscriptionTests(JuntagricoTestCaseWithShares):
             self.assertGet(reverse('part-order', args=[self.sub.pk]))
             post_data = {
                 f'amount[{type_id}]': 1 if i == 1 else 0
-                for i, type_id in enumerate(SubscriptionType.objects.values_list('id', flat=True))
+                for i, type_id in enumerate(SubscriptionType.objects.order_by('id').values_list('id', flat=True))
             }
             # order a type2 part, but with insufficient shares. Should fail, i.e., not change anything
             if settings.ENABLE_SHARES:

--- a/juntagrico/util/auth.py
+++ b/juntagrico/util/auth.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
+from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm, _unicode_ci_compare
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.models import User
 from django.contrib.auth.views import LoginView
@@ -76,6 +76,14 @@ class JuntagricoPasswordResetForm(PasswordResetForm):
         # custom sender
         sender = EmailSender.get_sender_from_email(email_message)
         sender.send()
+
+    def get_users(self, email):
+        active_members = Member.objects.active().filter(email__iexact=email)
+        return (
+            member.user
+            for member in active_members
+            if member.user.has_usable_password() and _unicode_ci_compare(email, member.email)
+        )
 
 
 class MultiplePermissionsRequiredMixin(PermissionRequiredMixin):


### PR DESCRIPTION
# Description
Fixes #318
