### PR TITLE
Fix: Future subscription deactivation via django admin

### DIFF
--- a/juntagrico/entity/__init__.py
+++ b/juntagrico/entity/__init__.py
@@ -59,14 +59,18 @@ class SimpleStateModel(models.Model):
         self.save()
 
     def cancel(self, date=None):
-        date = date or datetime.date.today()
+        today = datetime.date.today()
+        if date is None or date > today:
+            date = today
         self.cancellation_date = self.cancellation_date or date
         self.save()
 
     def deactivate(self, date=None):
-        date = date or datetime.date.today()
+        today = datetime.date.today()
+        date = date or today
         self.activation_date = self.activation_date or date  # allows immediate deactivation
-        self.cancellation_date = self.cancellation_date or date
+        if not self.cancellation_date:
+            self.cancellation_date = today if date > today else date  # can't cancel in the future
         self.deactivation_date = self.deactivation_date or date
         self.save()
 

--- a/juntagrico/tests/test_sub_admin.py
+++ b/juntagrico/tests/test_sub_admin.py
@@ -138,8 +138,9 @@ class SubAdminTests(JuntagricoTestCaseWithShares):
             [e.code for e in response.context_data['errors'].as_data()]
         )
 
-    def testDeactivation(self):
+    def testDeactivation(self, deactivation_date=None):
         # setup
+        deactivation_date = deactivation_date or '01.01.2018'
         sub = self.create_sub(self.depot, datetime.date(2017, 1, 1), [self.sub_type])
         self.member4.join_subscription(sub, True)
         sub_membership = sub.subscriptionmembership_set.first()
@@ -151,7 +152,7 @@ class SubAdminTests(JuntagricoTestCaseWithShares):
             'initial-start_date': '01.01.2017',
             'activation_date': '01.01.2017',
             'cancellation_date': '01.01.2018',
-            'deactivation_date': '01.01.2018',
+            'deactivation_date': deactivation_date,
             'notes': '',
             'subscriptionmembership_set-TOTAL_FORMS': '1',
             'subscriptionmembership_set-INITIAL_FORMS': '1',
@@ -173,3 +174,7 @@ class SubAdminTests(JuntagricoTestCaseWithShares):
         # test deactivation of sub, by setting only deactivation date of sub.
         self.assertPost(reverse('admin:juntagrico_subscription_change', args=[sub.id]),
                         data=data, member=self.admin, code=302)
+
+    def testFutureDeactivation(self):
+        future_date = datetime.date.today() + datetime.timedelta(days=2)
+        self.testDeactivation(future_date.strftime('%d.%m.%Y'))


### PR DESCRIPTION
# Description
#713 did not work if a future deactivation date is set. This PR fixes that.