### PR TITLE
admin/member: show member number in admin and to member (if set) #396

### DIFF
--- a/juntagrico/admins/member_admin.py
+++ b/juntagrico/admins/member_admin.py
@@ -12,14 +12,14 @@ from juntagrico.resources.member import MemberResource, MemberAssignmentsPerArea
 
 
 class MemberAdmin(DateRangeExportMixin, BaseAdmin):
-    list_display = ['email', 'first_name', 'last_name', 'addr_street', 'addr_zipcode', 'addr_location', 'active']
+    list_display = ['email', 'first_name', 'last_name', 'number', 'addr_street', 'addr_zipcode', 'addr_location', 'active']
     list_filter = ['user__is_superuser', 'user__is_staff', 'user__groups']
     search_fields = ['first_name', 'last_name', 'email', 'phone', 'mobile_phone',
-                     'addr_street', 'addr_zipcode', 'addr_location', 'id']
+                     'addr_street', 'addr_zipcode', 'addr_location', 'id', 'number']
     readonly_fields = ['user']
     inlines = [SubscriptionMembershipInline]
     fieldsets = [
-        (None, {'fields': ['first_name', 'last_name', 'birthday']}),
+        (None, {'fields': ['first_name', 'last_name', 'birthday', 'number']}),
         (_('Kontakt'), {'fields': ['email', 'confirmed', 'reachable_by_email', 'phone', 'mobile_phone']}),
         (_('Adresse'), {'fields': ['addr_street', 'addr_zipcode', 'addr_location']}),
         (_('Bankdaten'), {'fields': ['iban']}),

--- a/juntagrico/templates/profile.html
+++ b/juntagrico/templates/profile.html
@@ -24,14 +24,23 @@
                             {% endblocktrans %}
                         {% endblock %}
                     </div>
-                {% else %}
-                    {% if not member.inactive%}
-                        <div class="alert alert-success">
-                            {% block info_active %}
-                                {% blocktrans with v_member_type=vocabulary.member_type %}Deine {{ v_member_type }}schaft ist aktiv.{% endblocktrans %}
-                            {% endblock %}
-                        </div>
-                    {% endif %}
+                {% elif not member.inactive%}
+                    <div class="alert alert-success">
+                        {% block info_active %}
+                            {% blocktrans with v_member_type=vocabulary.member_type %}Deine {{ v_member_type }}schaft ist aktiv.{% endblocktrans %}
+                        {% endblock %}
+                    </div>
+                {% endif %}
+
+                {% if member.number %}
+                    <p>
+                        {% blocktrans trimmed with number=member.number %}
+                            Nummer: {{ number }}
+                        {% endblocktrans %}
+                    </p>
+                {% endif %}
+
+                {% if not member.canceled %}
                     {% block button_cancel_membership %}
                         <a href="{% url 'cancel-membership' %}" class="btn btn-outline-danger">
                             {% trans "Mitgliedschaft künden" %}


### PR DESCRIPTION
# Description
Implements #396: Member number can now be set in admin and will be shown to member in profile if set

![grafik](https://github.com/user-attachments/assets/6b326364-aba0-4acb-9d83-7baaf23fd2c5)
![grafik](https://github.com/user-attachments/assets/aa000cc0-aca2-4c30-912c-3f7a725b86fe)

