### PR TITLE
fix: show depots on map in selection view, even if only some depots have coordinates

### DIFF
--- a/juntagrico/static/juntagrico/js/juntagrico.js
+++ b/juntagrico/static/juntagrico/js/juntagrico.js
@@ -100,6 +100,8 @@ $.fn.AjaxSlider = function(activate_url, disable_url, placeholder='{value}') {
 
 function map_with_markers(locations, selected) {
     let markers = []
+    // only use locations with coordinates
+    locations = locations.filter(function (location) {return location.latitude && location.longitude})
     if (locations[0]) {
         $('#map-container').append('<div id="location-map">')
         let map = L.map('location-map').setView([locations[0].latitude, locations[0].longitude], 11);


### PR DESCRIPTION
# Description
If one depot location does not have coordinates, the map in the depot selection view broke
