### PR TITLE
dev: Add management command "createadmin" to replace "createsuperuser"

### DIFF
--- a/docs/contribute/development.rst
+++ b/docs/contribute/development.rst
@@ -46,9 +46,11 @@ Getting started
 .. code:: bash
 
    # Create local database and apply schemas
-   python manage.py migrate
+   python -m manage migrate
+   # Create a super user account
+   python -m manage createadmin
    # Start local development server on port 8000
-   python manage.py runserver 8000
+   python -m manage runserver 8000
 
 Generating documentation
 ------------------------

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -64,29 +64,24 @@ Add the juntagrico urls to you urls.py e.g.:
 Initial Django setup
 --------------------
 
-Use the django commands to set up the database e.g.:
+Use the django commands to set up the database:
 
 .. code-block:: bash
 
     $ python -m manage migrate
 
-In production (``DEBUG=False``) the static files must be collected e.g.:
+In production (``DEBUG=False``) the static files must be collected:
 
 .. code-block:: bash
 
     $ python -m manage collectstatic
 
-Create a superuser to login into your instance. e.g.:
+Create a superuser with member to login into your instance:
 
 .. code-block:: bash
 
-    $ python -m manage createsuperuser
+    $ python -m manage createadmin
 
-For juntagrico a member needs to be created for the super user using
-
-.. code-block:: bash
-
-    $ python -m manage create_member_for_superusers
 
 Create Test Data (optional)
 ---------------------------

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -6,11 +6,18 @@ Read the `official documentation <https://docs.djangoproject.com/en/4.2/ref/djan
 
 Call the commands with ``-h`` for more details on the usage.
 
+createadmin
+-----------
+
+This creates a super user like the command ``createsuperuser`` and creates a member for that new user,
+which is required by juntagrico to be able to log in.
+If you need to create members for previously created superusers, use ``create_member_for_superusers`` instead.
+
 create_member_for_superusers
 ----------------------------
 
-The django command ``createsuperuser`` will create a super user. However to be able to login juntagrico requires,
-that the user has a member. The command ``create_member_for_superusers`` will create such a member for all existing super users.
+The command ``create_member_for_superusers`` will create such a member for all existing super users.
+The member is required by juntagrico to be able to log in.
 
 .. _reference-generate-depot-list:
 

--- a/juntagrico/management/commands/create_member_for_superusers.py
+++ b/juntagrico/management/commands/create_member_for_superusers.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
-from django.db.models import signals
 
 from juntagrico.entity.member import Member
 
@@ -10,11 +9,10 @@ class Command(BaseCommand):
 
     # entry point used by manage.py
     def handle(self, *args, **options):
-        for user in User.objects.all():
-            if user.is_superuser and getattr(user, 'member', None) is None:
-                signals.pre_save.disconnect(Member.create, sender=Member)
-                member = Member.objects.create(user=user, first_name='super', last_name='duper', email=user.email,
-                                               addr_street='superstreet', addr_zipcode='8000',
-                                               addr_location='SuperCity', phone='012345678', confirmed=True)
-                member.save()
-                signals.pre_save.connect(Member.create, sender=Member)
+        members = Member.objects.bulk_create([
+            Member(user=user, first_name='super', last_name='duper', email=user.email,
+                   addr_street='superstreet', addr_zipcode='8000',
+                   addr_location='SuperCity', phone='012345678', confirmed=True)
+            for user in User.objects.filter(is_superuser=True, member__isnull=True)
+        ])
+        return f"Created {len(members)} member(s) for superusers."

--- a/juntagrico/management/commands/createadmin.py
+++ b/juntagrico/management/commands/createadmin.py
@@ -1,0 +1,26 @@
+from django.db.models import signals
+from django.contrib.auth.models import User
+from django.contrib.auth.management.commands import createsuperuser
+from juntagrico.entity.member import Member
+
+
+class Command(createsuperuser.Command):
+    help = "Use this instead of `createsuperuser` to create a super user with member."
+
+    @staticmethod
+    def _create_member(sender, **kwargs):
+        user = kwargs['instance']
+        if not hasattr(user, 'member'):
+            Member.objects.bulk_create([
+                Member(user=user, first_name='super', last_name=user.username, email=user.email,
+                       addr_street='superstreet', addr_zipcode='8000',
+                       addr_location='SuperCity', phone='012345678', confirmed=True)
+            ])
+
+    # entry point used by manage.py
+    def handle(self, *args, **options):
+        signals.post_save.connect(self._create_member, sender=User)
+        try:
+            super().handle(*args, **options)
+        finally:
+            signals.post_save.disconnect(self._create_member, sender=User)

--- a/juntagrico/tests/test_manage_cmds.py
+++ b/juntagrico/tests/test_manage_cmds.py
@@ -4,14 +4,21 @@ from django.core import mail
 from django.core.management import call_command
 
 from . import JuntagricoTestCaseWithShares
+from ..entity.member import Member
 
 
 class ManagementCommandsTest(JuntagricoTestCaseWithShares):
     def test_create_member_for_superuser(self):
-        call_command('createsuperuser', username='testsuperuer', email='super@mail.com', no_input='')
+        call_command('createsuperuser', username='testsuperuser', email='super@mail.com', no_input='')
         out = StringIO()
         call_command('create_member_for_superusers', stdout=out)
-        self.assertEqual(out.getvalue(), '')
+        self.assertEqual(out.getvalue(), 'Created 1 member(s) for superusers.\n')
+
+    def test_createadmin(self):
+        username = 'testsuperuser'
+        email = 'super@mail.com'
+        call_command('createadmin', username=username, email=email, no_input='')
+        self.assertEqual(Member.objects.get(user__username=username).email, email)
 
     def test_generate_testdata(self):
         out = StringIO()

--- a/testsettings.py
+++ b/testsettings.py
@@ -87,7 +87,6 @@ AUTHENTICATION_BACKENDS = (
 )
 
 MIDDLEWARE = [
-
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
# Description
`python -m manage createadmin` creates a super user with member, i.e. it replaces the use of the two commands `createsuperuser` and `create_member_for_superuser`.
The original commands still exist for other use cases.