### PR TITLE
fix: price of trials is not per year

### DIFF
--- a/juntagrico/entity/subtypes.py
+++ b/juntagrico/entity/subtypes.py
@@ -94,7 +94,7 @@ class SubscriptionType(JuntagricoBaseModel):
 
     def min_duration_info(self):
         if self.trial_days:
-            return _('{} Tage. Keine automatische Verlängerung.').format(self.trial_days)
+            return _('Für {} Tage. Keine automatische Verlängerung.').format(self.trial_days)
         if self.has_periods:
             return None  # price list already shows end of periods
         date = temporal.end_of_business_year()

--- a/juntagrico/templates/createsubscription/summary.html
+++ b/juntagrico/templates/createsubscription/summary.html
@@ -40,9 +40,15 @@
                         {{ period.price }} {% config "currency" %}
                     {% endfor %}
                 {% else %}
-                    {%blocktrans with tp=type.price%}
-                     à {{ c_currency }} {{ tp }}/Jahr.
-                    {%endblocktrans%}
+                    {% if type.trial_days %}
+                        {%blocktrans with tp=type.price%}
+                         à {{ c_currency }} {{ tp }}.
+                        {%endblocktrans%}
+                    {% else %}
+                        {%blocktrans with tp=type.price%}
+                         à {{ c_currency }} {{ tp }}/Jahr.
+                        {%endblocktrans%}
+                    {% endif %}
                     {{ type.min_duration_info }}
                 {% endif %}
                 {% if not forloop.last %}<br>{% endif %}


### PR DESCRIPTION
# Description
In the summary at the end of the signup a trial subscription price was shown as "per year", which is incorrect. Now it just shows the price. The  duration info in the next sentence makes it clear, that the price is for that period.
