### PR TITLE
admin: Setting to reduce job signup notification emails

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -732,6 +732,44 @@ MAILER_RICHTEXT_OPTIONS
 
     {}
 
+Notifications
+-------------
+
+ENABLE_NOTIFICATIONS
+^^^^^^^^^^^^^^^^^^^^
+  List of strings, of notifications that should be enabled:
+
+  -  `'job_subscribed'`: Send an email to the job admin, if a member signs up to a job without leaving a message.
+
+  example:
+
+  .. code-block:: python
+
+    ENABLE_NOTIFICATIONS = ['job_subscribed']
+
+  default value:
+
+  .. code-block:: python
+
+    []
+
+
+DISABLE_NOTIFICATIONS
+^^^^^^^^^^^^^^^^^^^^^
+
+  List of strings, of notifications that should be disabled:
+
+  - `'job_subscription_changed'`: Don't send an email to the job admin if a member changes their job signup without leaving a message.
+  - `'job_unsubscribed'`: Don't send an email to the job admin if a member unsubscribes from a job without leaving a message.
+
+  .. note::
+    Notifications are always sent, when the member leaves a message, because the message is not stored outside of the email.
+
+  default value:
+
+  .. code-block:: python
+
+    []
 
 GDPR
 ----

--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -199,6 +199,16 @@ class Config:
     )
     mailer_richtext_options = _get_setting('MAILER_RICHTEXT_OPTIONS', {})
 
+    @classmethod
+    def notifications(cls, name):
+        default_notifications = [
+            'job_subscription_changed',
+            'job_unsubscribed',
+        ]
+        enabled_notifications = getattr(settings, 'ENABLE_NOTIFICATIONS', []) + default_notifications
+        disabled_notifications = getattr(settings, 'DISABLE_NOTIFICATIONS', [])
+        return name in enabled_notifications and name not in disabled_notifications
+
     # demo settings
     demouser = _get_setting('DEMO_USER')
     demopwd = _get_setting('DEMO_PWD')

--- a/juntagrico/mailer/adminnotification.py
+++ b/juntagrico/mailer/adminnotification.py
@@ -137,16 +137,20 @@ def member_subscribed_to_job(job, **kwargs):
     if kwargs.get('message'):
         subject = _('Neue Anmeldung zum Einsatz mit Mitteilung')
     else:
+        if not Config.notifications('job_subscribed'):
+            return
         subject = _('Neue Anmeldung zum Einsatz')
     _template_member_in_job(job, subject, 'signup', **kwargs)
 
 
 def member_changed_job_subscription(job, **kwargs):
-    _template_member_in_job(job, _('Änderung der Einsatzanmeldung'), 'changed_subscription', **kwargs)
+    if Config.notifications('job_subscription_changed') or kwargs.get('message'):
+        _template_member_in_job(job, _('Änderung der Einsatzanmeldung'), 'changed_subscription', **kwargs)
 
 
 def member_unsubscribed_from_job(job, **kwargs):
-    _template_member_in_job(job, _('Abmeldung vom Einsatz'), 'unsubscribed', **kwargs)
+    if Config.notifications('job_unsubscribed') or kwargs.get('message'):
+        _template_member_in_job(job, _('Abmeldung vom Einsatz'), 'unsubscribed', **kwargs)
 
 
 def _template_assignment_changed(job, subject, template_name, **kwargs):

--- a/juntagrico/tests/test_jobs.py
+++ b/juntagrico/tests/test_jobs.py
@@ -34,7 +34,7 @@ class JobTests(JuntagricoTestCase):
             self.assertEqual(instance.pk, self.job1.pk)
             self.assertEqual(member, self.member)
 
-        self.assertPost(reverse('job', args=[self.job1.pk]), {'slots': 1, 'subscribe': True}, 302)
+        self.assertPost(reverse('job', args=[self.job1.pk]), {'slots': 1, 'subscribe': True, 'message': 'hello'}, 302)
         self.assertEqual(self.job1.free_slots, 0)
         self.assertEqual(self.job1.assignment_set.first().amount, 1)
         self.assertTrue(self.signal_called)
@@ -52,7 +52,7 @@ class JobTests(JuntagricoTestCase):
         # should override slots not add
         self.assertPost(reverse('job', args=[self.job4.pk]), {'slots': 1, 'subscribe': True}, 302)
         self.assertEqual(self.job4.assignment_set.count(), 1)
-        self.assertEqual(len(mail.outbox), 2)  # member and admin notification
+        self.assertEqual(len(mail.outbox), 1)  # member notification, no admin notification, because of no message
         mail.outbox = []
         self.assertGet(reverse('job', args=[self.job4.pk]))
         self.assertPost(reverse('job', args=[self.job4.pk]), {'slots': 2, 'subscribe': True}, 302)


### PR DESCRIPTION
# Description
Anticipating, that some will want to reduce the amount of the new job signup notification emails.
By default signups without message now cause no notification but can be enabled with `ENABLE_NOTIFICATIONS = ['job_subscribed']`. Changing or unsubscribing from a job without message will send a notification, but can be disabled with `DISABLE_NOTIFICATIONS`. See Docs.
This is a quick solution until #542 will allow for more flexibility.

# Release Notes
Added settings ENABLE_NOTIFICATIONS and DISABLE_NOTIFICATIONS
