### PR TITLE
fix: send share canceled notification email

### DIFF
--- a/juntagrico/apps.py
+++ b/juntagrico/apps.py
@@ -9,6 +9,8 @@ class JuntagricoAppconfig(AppConfig):
 
     def ready(self):
         from . import signals
-        from .models import Subscription
+        from .models import Subscription, Share
 
         signals.depot_changed.connect(signals.on_depot_changed, sender=Subscription)
+        signals.share_canceled.connect(signals.on_share_canceled, sender=Share)
+        # See models.py for older signal connections

--- a/juntagrico/fixtures/test/members.json
+++ b/juntagrico/fixtures/test/members.json
@@ -60,6 +60,11 @@
                 "share"
             ],
             [
+                "notified_on_share_cancellation",
+                "juntagrico",
+                "share"
+            ],
+            [
                 "can_send_mails",
                 "juntagrico",
                 "specialroles"

--- a/juntagrico/models.py
+++ b/juntagrico/models.py
@@ -46,6 +46,7 @@ class SpecialRoles(models.Model):
                        )
 
 
+# Don't connect new signals here, connect them in apps.py instead
 ''' non lifecycle related signals '''
 signals.pre_save.connect(Member.create, sender=Member)
 signals.post_delete.connect(Member.post_delete, sender=Member)
@@ -83,6 +84,7 @@ juntagrico.signals.member_created.connect(handle_member_created, sender=Member)
 juntagrico.signals.member_deactivated.connect(handle_member_deactivated, sender=Member)
 ''' lifecycle all post init'''
 register_entities_for_post_init_and_save()
+
 
 '''monkey patch User email method'''
 

--- a/juntagrico/signals.py
+++ b/juntagrico/signals.py
@@ -44,3 +44,7 @@ member_deactivated = Signal()
 
 def on_depot_changed(sender, **kwargs):
     adminnotification.member_changed_depot(**kwargs)
+
+
+def on_share_canceled(sender, instance, **kwargs):
+    adminnotification.share_canceled(instance, **kwargs)

--- a/juntagrico/tests/test_shares.py
+++ b/juntagrico/tests/test_shares.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.core import mail
 from django.test import tag
 from django.urls import reverse
 
@@ -9,6 +10,12 @@ from . import JuntagricoTestCase
 @tag('shares')
 class ShareTests(JuntagricoTestCase):
     fixtures = JuntagricoTestCase.fixtures + ['test/shares']
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.create_paid_share(cls.member)
+        mail.outbox.clear()
 
     def testShareManage(self):
         self.assertGet(reverse('manage-shares'), 200)
@@ -20,8 +27,22 @@ class ShareTests(JuntagricoTestCase):
         self.assertEqual(self.member2.share_set.count(), 1)
 
     def testShareCancel(self):
-        share = self.member.share_set.first()
+        share = self.member.share_set.last()
+        today = datetime.date.today()
         self.assertGet(reverse('share-cancel', args=[share.pk]), 302)
+        share.refresh_from_db()
+        self.assertEqual(share.cancelled_date, today)
+        self.assertNotEqual(share.termination_date, None)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].recipients(), ['email1@email.org'])
+
+    def testCancelWrongShare(self):
+        # should fail
+        share = self.member4.share_set.first()
+        self.assertGet(reverse('share-cancel', args=[share.pk]), 404)
+        share.refresh_from_db()
+        self.assertEqual(share.cancelled_date, None)
+        self.assertEqual(share.termination_date, None)
 
     def testSharePayout(self):
         share = self.member.share_set.first()

--- a/juntagrico/views_subscription.py
+++ b/juntagrico/views_subscription.py
@@ -28,7 +28,7 @@ from juntagrico.entity.subtypes import SubscriptionType
 from juntagrico.forms import RegisterMemberForm, EditMemberForm, AddCoMemberForm, SubscriptionPartOrderForm, \
     NicknameForm, SubscriptionPartChangeForm
 from juntagrico.mailer import membernotification, adminnotification
-from juntagrico.signals import depot_changed
+from juntagrico.signals import depot_changed, share_canceled
 from juntagrico.util import addons
 from juntagrico.util import temporal, return_to_previous_location
 from juntagrico.util.management import cancel_sub, create_subscription_parts
@@ -497,6 +497,7 @@ def cancel_share(request, share_id):
         share.cancelled_date = datetime.date.today()
         share.termination_date = next_membership_end_date()
         share.save()
+        share_canceled.send(sender=Share, instance=share)
     return return_to_previous_location(request)
 
 


### PR DESCRIPTION
# Description
Admin notification on canceled shares is documented (in permissions reference) but not implemented.
This PR adds the implementation.
