### PR TITLE
fix: Allow adding co-member on same day the left another subscription

### DIFF
--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -161,7 +161,15 @@ class Member(JuntagricoBaseModel):
             sub_membership.leave_date = None
             sub_membership.save()
         else:
-            join_date = None if subscription.waiting else datetime.date.today()
+            if subscription.waiting:
+                join_date = None
+            else:
+                today = datetime.date.today()
+                # allow common corner case, where co-member just left another subscription on the same day
+                if self.subscriptionmembership_set.filter(leave_date=today).exists():
+                    join_date = today + datetime.timedelta(days=1)
+                else:
+                    join_date = today
             SubscriptionMembership.objects.create(member=self, subscription=subscription, join_date=join_date)
         if primary:
             subscription.primary_member = self

--- a/juntagrico/forms.py
+++ b/juntagrico/forms.py
@@ -325,7 +325,7 @@ class CoMemberBaseForm(MemberBaseForm):
         email = self.cleaned_data['email'].lower()
         if email in self.existing_emails:
             raise ValidationError(mark_safe(_('Diese E-Mail-Adresse wird bereits von dir oder deinen {} verwendet.')
-                                            .format(Config.vocabulary('co_member_pl'))))
+                                            .format(Config.vocabulary('co_member_pl'))), 'email_exists')
         existing_member = MemberDao.member_by_email(email)
         if existing_member:
             if existing_member.blocked:
@@ -335,7 +335,7 @@ class CoMemberBaseForm(MemberBaseForm):
                     '<a href="mailto:{0}">{0}</a>'.format(Config.contacts('for_subscriptions')),
                     Config.vocabulary('member_type_pl'),
                     Config.vocabulary('co_member_pl')
-                )))
+                )), 'has_active_subscription')
             else:
                 # store existing member for reevaluation
                 self.existing_member = existing_member

--- a/juntagrico/tests/test_comember.py
+++ b/juntagrico/tests/test_comember.py
@@ -82,7 +82,6 @@ class CoMemberTests(JuntagricoTestCase):
             ).exists()
         )
 
-
     def testAddExistingCoMember(self):
         co_member_before = self.co_member.__dict__
         new_co_member_data = self.get_co_member_data(self.co_member.email)

--- a/juntagrico/tests/test_comember.py
+++ b/juntagrico/tests/test_comember.py
@@ -1,8 +1,10 @@
+import datetime
+
 from django.conf import settings
 from django.core import mail
 from django.urls import reverse
 
-from juntagrico.models import Member, Share, Subscription
+from juntagrico.models import Member, Share, Subscription, SubscriptionMembership
 from . import JuntagricoTestCase
 
 
@@ -12,6 +14,15 @@ class CoMemberTests(JuntagricoTestCase):
     def setUpTestData(cls):
         super().setUpTestData()
         cls.co_member = cls.create_member('co_member@email.org', iban='CH6189144414396247884')
+        # add member, that just left another subscription
+        cls.switching_co_member = cls.create_member('co_member2@email.org', iban='CH6189144414396247884')
+        cls.old_sub = cls.create_sub(cls.depot, datetime.date(2025, 1, 27), [cls.sub_type])
+        SubscriptionMembership.objects.create(
+            member=cls.switching_co_member,
+            subscription=cls.old_sub,
+            join_date=cls.old_sub.activation_date,
+            leave_date=datetime.date.today(),
+        )
         mail.outbox.clear()
 
     @staticmethod
@@ -48,11 +59,29 @@ class CoMemberTests(JuntagricoTestCase):
         # message to contact admin will show
         new_co_member_data = self.get_co_member_data(self.member2.email)
         # response is 200 (form error)
-        self.assertPost(reverse('add-member', args=[self.sub.pk]), new_co_member_data)
+        response = self.assertPost(reverse('add-member', args=[self.sub.pk]), new_co_member_data)
+        self.assertListEqual(
+            ['has_active_subscription'],  # first code 'part_activation_date_mismatch' reaches here as none somehow
+            [e.code for e in response.context_data['form'].errors['email'].as_data()]
+        )
         # no new shares should be created
         self.assertEqual(Share.objects.filter(member=self.member2).count(), 0)
         # member now is not part of subscription
         self.assertNotEqual(self.member2.subscription_current, self.sub)
+
+    def testAddExistingCoMemberWithSubEndingSameDay(self):
+        # corner case: co-member just left their other subscription today. New subscription will be joined tomorrow
+        new_co_member_data = self.get_co_member_data(self.switching_co_member.email)
+        self.assertPost(reverse('add-member', args=[self.sub.pk]), new_co_member_data, 302)
+        self.switching_co_member.refresh_from_db()
+        self.assertIsNone(self.co_member.subscription_current)
+        self.assertTrue(
+            self.switching_co_member.subscriptionmembership_set.filter(
+                subscription=self.sub,
+                join_date=datetime.date.today() + datetime.timedelta(days=1)
+            ).exists()
+        )
+
 
     def testAddExistingCoMember(self):
         co_member_before = self.co_member.__dict__


### PR DESCRIPTION
# Description
When adding an existing member as a co-member on the same day that that member left another subscription, the server crashes (500).
This fix handles the case of adding a co-member on the same day they left another subscription by adding them to the new subscription tomorrow.