### PR TITLE
member: Clearer explanation on membership cancellation page

### DIFF
--- a/juntagrico/templates/cancelmembership.html
+++ b/juntagrico/templates/cancelmembership.html
@@ -63,12 +63,20 @@
         <div class="col-md-12">
             {% if can_cancel %}
                {%  crispy form %}
-            {% elif share_error %}
-                {% blocktrans trimmed %}
-                Deine {{ v_share_pl }} werden noch benötigt in einem Abo.
-                {% endblocktrans %}
             {% else %}
-                {% blocktrans%}Du bist noch in eine/r/m {{ v_subscription }} als BezieherIn eingetragen.{% endblocktrans %}
+                <div class="alert alert-danger">
+                    {% blocktrans trimmed %}
+                        Du kannst deine Mitgliedschaft aus folgenden Gründen noch nicht kündigen:
+                    {% endblocktrans %}
+                    <br>
+                    {% if share_error %}
+                        {% blocktrans trimmed %}
+                        Deine {{ v_share_pl }} werden noch benötigt in einem Abo.
+                        {% endblocktrans %}
+                    {% else %}
+                        {% blocktrans%}Du bist noch in eine/r/m {{ v_subscription }} als BezieherIn eingetragen.{% endblocktrans %}
+                    {% endif %}
+                </div>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
So far members were shown this membership cancellation page, if they still had shares required by a subscription.
![grafik](https://github.com/user-attachments/assets/d03afef3-eb55-44d1-b74e-d414c53c7279)
The description did not make it clear, that an action was required by the member.

this PR makes the description clearer and highlights the relevant text.
![grafik](https://github.com/user-attachments/assets/5b77ddce-6fad-4ecb-907b-b0f1530e47ce)

#554 should make it easier, to do the requested steps, i.e. cancel the subscription, directly on this cancellation page.