### PR TITLE
fix: Display type description correctly in job admin and during mass copy

### DIFF
--- a/juntagrico/admins/__init__.py
+++ b/juntagrico/admins/__init__.py
@@ -1,10 +1,10 @@
-from django.conf import settings
 from django.contrib import admin
 from django.db.models import TextField
 from djrichtextfield.widgets import RichTextWidget
 from import_export.admin import ExportMixin
 
 from juntagrico.admins.forms.import_export_form import ExportAssignmentDateRangeForm
+from juntagrico.config import Config
 from juntagrico.util import addons
 
 
@@ -19,7 +19,7 @@ class BaseAdmin(admin.ModelAdmin):
 class RichTextAdmin(BaseAdmin):
 
     def __init__(self, model, admin_site):
-        if 'djrichtextfield' in settings.INSTALLED_APPS and hasattr(settings, 'DJRICHTEXTFIELD_CONFIG'):
+        if Config.using_richtext():
             self.formfield_overrides = self.formfield_overrides or {}
             self.formfield_overrides.update({TextField: {'widget': RichTextWidget}})
         super().__init__(model, admin_site)

--- a/juntagrico/admins/forms/job_copy_form.py
+++ b/juntagrico/admins/forms/job_copy_form.py
@@ -9,6 +9,7 @@ from django.utils.timezone import get_default_timezone as gdtz, localtime, is_na
 from django.utils.translation import gettext as _
 from djrichtextfield.widgets import RichTextWidget
 
+from juntagrico.config import Config
 from juntagrico.entity.jobs import RecuringJob
 from juntagrico.util.temporal import weekday_choices
 
@@ -44,7 +45,7 @@ class JobCopyForm(forms.ModelForm):
             self.fields['time'].initial = localtime(inst.time)
         self.fields['weekdays'].initial = [inst.time.isoweekday()]
 
-        if 'djrichtextfield' in settings.INSTALLED_APPS and hasattr(settings, 'DJRICHTEXTFIELD_CONFIG'):
+        if Config.using_richtext():
             self.fields['additional_description'].widget = RichTextWidget()
 
         self.new_jobs = []

--- a/juntagrico/admins/forms/job_copy_form.py
+++ b/juntagrico/admins/forms/job_copy_form.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.timezone import get_default_timezone as gdtz, localtime, is_naive
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _ly
 
 from juntagrico.entity.jobs import RecuringJob
 from juntagrico.util.temporal import weekday_choices
@@ -17,18 +18,18 @@ class JobCopyForm(forms.ModelForm):
         model = RecuringJob
         fields = []
 
-    weekdays = forms.MultipleChoiceField(label=_('Wochentage'), choices=weekday_choices,
+    weekdays = forms.MultipleChoiceField(label=_ly('Wochentage'), choices=weekday_choices,
                                          widget=forms.widgets.CheckboxSelectMultiple)
 
-    new_time = forms.TimeField(label=_('Zeit'), required=True,
+    new_time = forms.TimeField(label=_ly('Zeit'), required=True,
                                widget=admin.widgets.AdminTimeWidget)
 
-    start_date = forms.DateField(label=_('Anfangsdatum'), required=True,
+    start_date = forms.DateField(label=_ly('Anfangsdatum'), required=True,
                                  widget=admin.widgets.AdminDateWidget)
-    end_date = forms.DateField(label=_('Enddatum'), required=True,
+    end_date = forms.DateField(label=_ly('Enddatum'), required=True,
                                widget=admin.widgets.AdminDateWidget)
 
-    weekly = forms.ChoiceField(choices=[(7, _('jede Woche')), (14, _('Alle zwei Wochen'))],
+    weekly = forms.ChoiceField(label=_ly('Frequenz'), choices=[(7, _ly('jede Woche')), (14, _ly('Alle zwei Wochen'))],
                                widget=forms.widgets.RadioSelect, initial=7)
 
     def __init__(self, *a, **k):

--- a/juntagrico/admins/forms/job_copy_form.py
+++ b/juntagrico/admins/forms/job_copy_form.py
@@ -7,9 +7,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.timezone import get_default_timezone as gdtz, localtime, is_naive
 from django.utils.translation import gettext as _
-from djrichtextfield.widgets import RichTextWidget
 
-from juntagrico.config import Config
 from juntagrico.entity.jobs import RecuringJob
 from juntagrico.util.temporal import weekday_choices
 
@@ -44,9 +42,6 @@ class JobCopyForm(forms.ModelForm):
         else:
             self.fields['new_time'].initial = localtime(inst.time)
         self.fields['weekdays'].initial = [inst.time.isoweekday()]
-
-        if Config.using_richtext():
-            self.fields['additional_description'].widget = RichTextWidget()
 
         self.new_jobs = []
 

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -53,7 +53,7 @@ class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTe
             'type', ('duration_override', 'type_duration'), 'multiplier', ('slots', 'infinite_slots'),
             'type_description', 'additional_description'
         ]}),
-        (gettext_lazy('Kopieren nach'), { 'fields': [
+        (gettext_lazy('Kopieren nach'), {'fields': [
             'new_time', 'start_date', 'end_date', 'weekdays', 'weekly'
         ]}),
     ]

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -18,6 +18,7 @@ from juntagrico.admins.inlines.assignment_inline import AssignmentInline
 from juntagrico.admins.inlines.contact_inline import ContactInline
 from juntagrico.dao.jobtypedao import JobTypeDao
 from juntagrico.entity.jobs import RecuringJob, JobType
+from juntagrico.templatetags.juntagrico.common import richtext
 from juntagrico.util.admin import formfield_for_coordinator, queryset_for_coordinator
 
 
@@ -58,7 +59,7 @@ class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTe
     @admin.display(description=_('Beschreibung der Jobart'))
     def type_description(self, instance):
         # when adding a new job, instance is an empty job queryset
-        return type_div('description', instance.type.description if instance.type_id else None)
+        return type_div('description', richtext(instance.type.description) if instance.type_id else None)
 
     @admin.display(description=_('Standardwert'))
     def type_duration(self, instance):

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -48,7 +48,8 @@ class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTe
     fields = ('type', 'time', ('duration_override', 'type_duration'), 'multiplier', ('slots', 'infinite_slots', 'free_slots'),
               'type_description', 'additional_description', 'pinned', 'canceled')
     copy_fields = ('type', ('duration_override', 'type_duration'), 'multiplier', ('slots', 'infinite_slots'),
-                  'type_description', 'additional_description', 'weekdays', 'new_time', 'start_date', 'end_date', 'weekly')
+                   'type_description', 'additional_description',
+                   'weekdays', 'new_time', 'start_date', 'end_date', 'weekly')
     list_display = ['__str__', 'type', 'time', 'slots', 'free_slots']
     list_filter = (('type__activityarea', admin.RelatedOnlyFieldListFilter), ('time', FutureDateTimeFilter))
     actions = ['copy_job', 'mass_copy_job']

--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -200,6 +200,10 @@ class Config:
     mailer_richtext_options = _get_setting('MAILER_RICHTEXT_OPTIONS', {})
 
     @classmethod
+    def using_richtext(cls):
+        return 'djrichtextfield' in settings.INSTALLED_APPS and hasattr(settings, 'DJRICHTEXTFIELD_CONFIG')
+
+    @classmethod
     def notifications(cls, name):
         default_notifications = [
             'job_subscription_changed',

--- a/juntagrico/templatetags/juntagrico/common.py
+++ b/juntagrico/templatetags/juntagrico/common.py
@@ -1,8 +1,8 @@
 from django import template
-from django.conf import settings
 from django.template.defaultfilters import urlize, linebreaksbr
 
 from juntagrico import __version__
+from juntagrico.config import Config
 from juntagrico.dao.activityareadao import ActivityAreaDao
 from juntagrico.dao.deliverydao import DeliveryDao
 from juntagrico.dao.depotdao import DepotDao
@@ -84,7 +84,7 @@ def get_version():
 
 @register.filter
 def richtext(value):
-    if 'djrichtextfield' not in settings.INSTALLED_APPS or not hasattr(settings, 'DJRICHTEXTFIELD_CONFIG'):
+    if not Config.using_richtext():
         value = urlize(value)
         value = linebreaksbr(value)
     return value

--- a/juntagrico/tests/test_adminforms.py
+++ b/juntagrico/tests/test_adminforms.py
@@ -41,7 +41,7 @@ class JobFormTests(JuntagricoTestCase):
         # test 0 copies (fails)
         initial_count = RecuringJob.objects.all().count()
         data = {'type': self.job1.type.pk,
-                'time': '05:04:53',
+                'new_time': '05:04:53',
                 'slots': '2',
                 'weekdays': ['1'],
                 'start_date': '26.07.2020',
@@ -57,7 +57,7 @@ class JobFormTests(JuntagricoTestCase):
         # test 1 copy
         self.complex_job.time = datetime.datetime.now()
         data = {'type': self.complex_job.type.pk,
-                'time': '05:04:53',
+                'new_time': '05:04:53',
                 'slots': '2',
                 'weekdays': ['1'],
                 'start_date': '01.07.2020',
@@ -74,7 +74,7 @@ class JobFormTests(JuntagricoTestCase):
         self.assertEqual(self.complex_job.type, new_job.type)
         self.assertEqual(self.complex_job.slots, new_job.slots)
         self.assertEqual(self.complex_job.infinite_slots, new_job.infinite_slots)
-        dt = datetime.datetime.fromisoformat('2020-07-06T' + data['time'])
+        dt = datetime.datetime.fromisoformat('2020-07-06T' + data['new_time'])
         if settings.USE_TZ:
             dt = dt.astimezone(timezone.get_default_timezone())
         self.assertEqual(dt, new_job.time)
@@ -83,7 +83,7 @@ class JobFormTests(JuntagricoTestCase):
         self.assertEqual(self.complex_job.duration_override, new_job.duration_override)
         # Test 2 copies
         data = {'type': self.job1.type.pk,
-                'time': '05:04:53',
+                'new_time': '05:04:53',
                 'slots': '2',
                 'weekdays': ['1'],
                 'start_date': '01.07.2020',
@@ -105,7 +105,7 @@ class JobFormTests(JuntagricoTestCase):
             "additional_description": "New Description",
             "duration_override": "9",
             "weekdays": "2",
-            "time": "13:46:46",
+            "new_time": "13:46:46",
             "start_date": "18.06.2024",
             "end_date": "19.06.2024",
             "weekly": "7",
@@ -148,7 +148,7 @@ class JobFormTests(JuntagricoTestCase):
         self.assertEqual(new_job.type, self.complex_job.type)
         self.assertEqual(new_job.slots, 2)
         self.assertEqual(new_job.infinite_slots, False)
-        dt = datetime.datetime.fromisoformat('2024-06-18T' + data['time'])
+        dt = datetime.datetime.fromisoformat('2024-06-18T' + data['new_time'])
         if settings.USE_TZ:
             dt = dt.astimezone(timezone.get_default_timezone())
         self.assertEqual(new_job.time, dt)
@@ -161,7 +161,7 @@ class JobFormTests(JuntagricoTestCase):
         # test failing case
         initial_count = RecuringJob.objects.all().count()
         data = {'type': self.job1.type.pk,
-                'time': '05:04:53',
+                'new_time': '05:04:53',
                 'slots': '2',
                 'weekdays': ['1'],
                 'start_date': '01.07.2020',
@@ -178,7 +178,7 @@ class JobFormTests(JuntagricoTestCase):
         today = datetime.date.today()
         # test successful case
         data = {'type': self.job1.type.pk,
-                'time': '05:04:53',
+                'new_time': '05:04:53',
                 'slots': '2',
                 'weekdays': ['1'],
                 'start_date': today + datetime.timedelta(1),

--- a/juntagrico/views/api.py
+++ b/juntagrico/views/api.py
@@ -2,11 +2,12 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 
 from juntagrico.entity.jobs import JobType
+from juntagrico.templatetags.juntagrico.common import richtext
 
 
 @login_required
 def job_type_description(request, id):
-    return HttpResponse(JobType.objects.get(id=id).description)
+    return HttpResponse(richtext(JobType.objects.get(id=id).description))
 
 
 @login_required


### PR DESCRIPTION
Fixes the dynamic preview of #752 and adds it to the job copy form as well.
Clean up job copy form in general.