### PR TITLE
fix: jobtype autocomplete in job admin form for area admins

### DIFF
--- a/juntagrico/admins/job_type_admin.py
+++ b/juntagrico/admins/job_type_admin.py
@@ -77,7 +77,8 @@ class JobTypeAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, Ri
 
     def get_queryset(self, request):
         qs = queryset_for_coordinator(self, request, 'activityarea__coordinator')
-        qs = qs.annotate(last_used=Max('recuringjob__time'))
+        if request.resolver_match.view_name != 'admin:autocomplete':
+            qs = qs.annotate(last_used=Max('recuringjob__time'))
         return qs
 
     def get_search_results(self, request, queryset, search_term):

--- a/juntagrico/tests/test_admin.py
+++ b/juntagrico/tests/test_admin.py
@@ -37,6 +37,11 @@ class AdminTests(JuntagricoTestCaseWithShares):
         # delete job with assignment (will show a page, that assignments must be deleted first)
         self.assertGet(reverse('admin:juntagrico_recuringjob_delete', args=(self.job2.pk,)), member=self.admin)
 
+    def testJobTypeAutocomplete(self):
+        url = reverse('admin:autocomplete') + '?app_label=juntagrico&model_name=recuringjob&field_name=type'
+        self.assertGet(url, member=self.admin)
+        self.assertGet(url, member=self.area_admin)
+
     def testPastJobAdmin(self):
         add_url = reverse('admin:juntagrico_recuringjob_add')
         self.assertGet(add_url, member=self.area_admin)


### PR DESCRIPTION
When an area admin opened the autocomplete field for the jobtype in the job admin change/add form, the server would crash, returning no results.

The issue seems to be the annotation in the queryset. It is not needed for the autocomplete field, so the solution is to not apply it in that case.