### PR TITLE
fix sticky datatable top

### DIFF
--- a/juntagrico/static/juntagrico/css/juntagrico.css
+++ b/juntagrico/static/juntagrico/css/juntagrico.css
@@ -329,7 +329,7 @@ textarea#recipients[disabled=disabled] {
     top: 0;
 }
 
-#filter-table_wrapper > div.justify-content-between {
+#filter-table_wrapper > div.table-button-row {
     position: sticky;
     top: 0;
 	z-index: 2;

--- a/juntagrico/templates/juntagrico/manage/base.html
+++ b/juntagrico/templates/juntagrico/manage/base.html
@@ -30,13 +30,16 @@
                         },
                         layout: {
                             topStart: {
-                                buttons: [
-                                    email_button(
-                                        '{% if mail_url %}{% url mail_url %}{% else %}{% url 'mail' %}{% endif %}',
-                                        '{% csrf_token %}'
-                                    ),
-                                    email_copy_button()
-                                ]
+                                rowClass: 'row justify-content-between table-button-row',
+                                features: [{
+                                    buttons: [
+                                        email_button(
+                                            '{% if mail_url %}{% url mail_url %}{% else %}{% url 'mail' %}{% endif %}',
+                                            '{% csrf_token %}'
+                                        ),
+                                        email_copy_button()
+                                    ]
+                                }]
                             }
                         },
                     }


### PR DESCRIPTION
Fixes regression from #770: The row with buttons and search field on some datatables must be sticky when scrolling.