### PR TITLE
Fix wording for assignments when using hours

### DIFF
--- a/juntagrico/templates/juntagrico/job/snippets/edit_assignment.html
+++ b/juntagrico/templates/juntagrico/job/snippets/edit_assignment.html
@@ -6,8 +6,8 @@
     </div>
 {% endif %}
 <p>
-    {% blocktrans trimmed with m=member %}
-    	Du änderst den Einsatz von {{ m }}
+    {% blocktrans trimmed with v_assignment=vocabulary.assignment m=member %}
+    	Du änderst den/die/das {{ v_assignment }} von {{ m }}
     {% endblocktrans %}
 </p>
 {% crispy form %}

--- a/juntagrico/templates/juntagrico/job/snippets/participant_list.html
+++ b/juntagrico/templates/juntagrico/job/snippets/participant_list.html
@@ -49,12 +49,16 @@
 {% endif %}
 
 {# Modal for editing assignment #}
-{% if can_edit or True %}
+{% if can_edit_assignments %}
     <div class="modal" id="edit_assignment_modal" tabindex="-1">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">{% trans "Einsatz bearbeiten" %}</h5>
+                    <h5 class="modal-title">
+                        {% blocktrans trimmed with v_assignment=vocabulary.assignment %}
+                            {{ v_assignment }} bearbeiten
+                        {% endblocktrans %}
+                    </h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>

--- a/juntagrico/templates/juntagrico/my/assignment/snippets/subscription_overview.html
+++ b/juntagrico/templates/juntagrico/my/assignment/snippets/subscription_overview.html
@@ -9,33 +9,33 @@
     <div class="col-md-9">
         <div class="mb-3">
             {% vocabulary "subscription" as v_subscription %}
-            {% blocktrans trimmed with ra=subscription.required_assignments|floatformat:-1 rca=subscription.required_core_assignments|floatformat:-1 %}
-                Benötigt für diese/n/s {{ v_subscription }}: {{ ra }}
+            {% blocktrans trimmed with ra=subscription.required_assignments|floatformat:-1 %}
+                Benötigt für diese/n/s {{ v_subscription }}: {{ ra }}{{ unit }}
             {% endblocktrans %}
             {% if subscription.required_core_assignments %}
                 {% blocktrans trimmed with rca=subscription.required_core_assignments|floatformat:-1 %}
-                    (Davon {{ rca }} in Kernbereichen)
+                    (Davon {{ rca }}{{ unit }} in Kernbereichen)
                 {% endblocktrans %}
             {% endif %}
         </div>
         <div class="mb-3">
             {% blocktrans trimmed with mac=subscription.member_assignment_count|floatformat:-1 %}
-                Du hast selbst {{ mac }} gemacht oder geplant
+                Du hast selbst {{ mac }}{{ unit }} gemacht oder geplant
             {% endblocktrans %}
             {% if subscription.required_core_assignments %}
                 {% blocktrans trimmed with mcac=subscription.member_core_assignment_count|floatformat:-1 %}
-                    (Davon {{ mcac }} in Kernbereichen)
+                    (Davon {{ mcac }}{{ unit }} in Kernbereichen)
                 {% endblocktrans %}
             {% endif %}
         </div>
         {% if co_members %}
             <div class="mb-3">
                 {% blocktrans trimmed with ac=subscription.assignment_count|floatformat:-1  %}
-                    Zusammen mit deinen {{ v_co_member_pl }} hast du {{ ac }} gemacht oder geplant
+                    Zusammen mit deinen {{ v_co_member_pl }} hast du {{ ac }}{{ unit }} gemacht oder geplant
                 {% endblocktrans %}
                 {% if subscription.required_core_assignments %}
                     {% blocktrans trimmed with cac=subscription.core_assignment_count|floatformat:-1 %}
-                        (Davon {{ cac }} in Kernbereichen)
+                        (Davon {{ cac }}{{ unit }} in Kernbereichen)
                     {% endblocktrans %}
                 {% endif %}
             </div>

--- a/juntagrico/templates/juntagrico/widgets/assignment_progress.html
+++ b/juntagrico/templates/juntagrico/widgets/assignment_progress.html
@@ -11,6 +11,11 @@
     {% block progress %}
         {% assignment_progress request.user.member future=True as assignments %}
         {% include "./assignment_progress/bars.html" %}
-        {% include "./assignment_progress/text.html" %}
+        {% config 'assignment_unit' as unit %}
+        {% if unit == 'HOURS' %}
+            {% include "./assignment_progress/text_hours.html" %}
+        {% else %}
+            {% include "./assignment_progress/text.html" %}
+        {% endif %}
     {% endblock %}
 </div>

--- a/juntagrico/templates/juntagrico/widgets/assignment_progress/text_hours.html
+++ b/juntagrico/templates/juntagrico/widgets/assignment_progress/text_hours.html
@@ -1,0 +1,69 @@
+{% load i18n %}
+<div class="assignment-progress assignment-progress-text">
+    {% if assignments.subscription %}
+        {% with sub=assignments.subscription %}
+            {% if assignments.future is None %}
+                {% if sub.co_members.count %}
+                    {% blocktrans trimmed with c=sub.assignment_count|floatformat %}
+                        Ihr habt diese Saison bisher {{ c }}h geleistet oder geplant.
+                    {% endblocktrans %}
+                {% else %}
+                    {% blocktrans trimmed with c=sub.assignment_count|floatformat %}
+                        Du hast diese Saison bisher {{ c }}h geleistet oder geplant.
+                    {% endblocktrans %}
+                {% endif %}
+            {% else %}
+                {% if sub.co_members.exists %}
+                    {% blocktrans trimmed with c=sub.assignment_count|floatformat %}
+                        Ihr habt diese Saison bisher {{ c }}h geleistet.
+                    {% endblocktrans %}
+                {% else %}
+                    {% blocktrans trimmed with c=sub.assignment_count|floatformat %}
+                        Du hast diese Saison bisher {{ c }}h geleistet.
+                    {% endblocktrans %}
+                {% endif %}
+            {% endif %}
+            {% if sub.required_core_assignments > 0 %}
+                {% blocktrans trimmed with c=sub.core_assignment_count|floatformat %}
+                    Davon {{ c }}h in Kernbereichen.
+                {% endblocktrans %}
+            {% endif %}
+            {% if sub.co_members.exists %}
+                {% blocktrans trimmed with r=sub.required_assignments|floatformat %}
+                    Ihr benötigt insgesamt {{ r }}h.
+                {% endblocktrans %}
+            {% else %}
+                {% blocktrans trimmed with r=sub.required_assignments|floatformat %}
+                    Du benötigst insgesamt {{ r }}h.
+                {% endblocktrans %}
+            {% endif %}
+            {% if sub.required_core_assignments > 0 %}
+                {% blocktrans trimmed with r=sub.required_core_assignments|floatformat %}
+                    Davon {{ r }}h in Kernbereichen.
+                {% endblocktrans %}
+            {% endif %}
+            {% if sub.future_assignment_count %}
+                <br>
+                {% blocktrans trimmed with c=sub.future_assignment_count|floatformat count p=sub.future_assignment_count %}
+                    {{ c }} weitere Stunde ist schon geplant.
+                {% plural %}
+                    {{ c }} weitere Stunden sind schon geplant.
+                {% endblocktrans %}
+            {% endif %}
+        {% endwith %}
+    {% else %}
+        {% with member=assignments.member %}
+            {% blocktrans trimmed with c=member.assignment_count|floatformat %}
+                Du hast diese Saison {{ c }}h geleistet.
+            {% endblocktrans %}
+            {% if member.future_assignment_count %}
+                <br>
+                {% blocktrans trimmed with c=member.future_assignment_count|floatformat count p=member.future_assignment_count %}
+                    {{ c }} weiteren Stunde hast du schon geplant.
+                {% plural %}
+                    {{ c }} weitere Stunden hast du schon geplant.
+                {% endblocktrans %}
+            {% endif %}
+        {% endwith %}
+    {% endif %}
+</div>

--- a/juntagrico/views/subscription.py
+++ b/juntagrico/views/subscription.py
@@ -4,6 +4,7 @@ from django.contrib.auth.decorators import login_required
 from django.db.models import F
 from django.shortcuts import get_object_or_404, render, redirect
 
+from juntagrico.config import Config
 from juntagrico.entity.subs import Subscription
 from juntagrico.entity.subtypes import SubscriptionType, SubscriptionProduct
 from juntagrico.forms import SubscriptionPartOrderForm
@@ -68,7 +69,8 @@ def single(request, subscription_id=None):
         'subscription': subscription,
         'subscription_membership': subscription_membership,
         'can_change_part': SubscriptionType.objects.normal().visible().count() > 1,
-        'has_extra': SubscriptionType.objects.is_extra().visible().exists()
+        'has_extra': SubscriptionType.objects.is_extra().visible().exists(),
+        'unit': 'h' if Config.assignment_unit() == 'HOURS' else '',
     })
 
 


### PR DESCRIPTION
These texts previously did not consider the assignment unit. This PR fixes that

![grafik](https://github.com/user-attachments/assets/80dd3f26-b656-49bd-95a9-781c8eccf897)
![grafik](https://github.com/user-attachments/assets/e6856cb0-9043-43e7-ab43-28e052753f73)
