### PR TITLE
admin: Define multi-column sort for date column in recent subscription changes management table

### DIFF
--- a/juntagrico/templates/juntagrico/manage/subscription/recent.html
+++ b/juntagrico/templates/juntagrico/manage/subscription/recent.html
@@ -180,5 +180,6 @@
 {% block datatable_constructor %}
     {{ block.super }}
     config.ordering = true
-    config.order = [[1, 'desc'], [2, 'desc'], [0, 'desc']]
+    config.order = [[1, 'desc']]
+    config.columnDefs = [{ orderData: [1, 2, 0], targets: 1 }]
 {% endblock %}

--- a/juntagrico/templates/juntagrico/manage/subscription/recent.html
+++ b/juntagrico/templates/juntagrico/manage/subscription/recent.html
@@ -62,7 +62,7 @@
             {% for deactivated_part in deactivated_parts %}
                 <tr>
                     <td>
-                        {% trans "Deaktivierung" %}
+                        <span class="d-none">6</span>{% trans "Deaktivierung" %}
                     </td>
                     <td>
                         {{ deactivated_part.deactivation_date|date:"Y-m-d" }}
@@ -81,7 +81,7 @@
             {% for cancelled_part in cancelled_parts %}
                 <tr>
                     <td>
-                        {% trans "Kündigung" %}
+                        <span class="d-none">5</span>{% trans "Kündigung" %}
                     </td>
                     <td>
                         {{ cancelled_part.cancellation_date|date:"Y-m-d" }}
@@ -100,7 +100,7 @@
             {% for left_membership in left_memberships %}
                 <tr>
                     <td>
-                        {% trans "Austritt" %}
+                        <span class="d-none">4</span>{% trans "Austritt" %}
                     </td>
                     <td>
                         {{ left_membership.leave_date|date:"Y-m-d" }}
@@ -119,7 +119,7 @@
             {% for joined_membership in joined_memberships %}
                 <tr>
                     <td>
-                        {% trans "Beitritt" %}
+                        <span class="d-none">3</span>{% trans "Beitritt" %}
                     </td>
                     <td>
                         {{ joined_membership.join_date|date:"Y-m-d" }}
@@ -138,7 +138,7 @@
             {% for activated_part in activated_parts %}
                 <tr>
                     <td>
-                        {% trans "Aktivierung" %}
+                        <span class="d-none">2</span>{% trans "Aktivierung" %}
                     </td>
                     <td>
                         {{ activated_part.activation_date|date:"Y-m-d" }}
@@ -157,7 +157,7 @@
             {% for ordered_part in ordered_parts %}
                 <tr>
                     <td>
-                        {% trans "Bestellung" %}
+                        <span class="d-none">1</span>{% trans "Bestellung" %}
                     </td>
                     <td>
                         {{ ordered_part.creation_date|date:"Y-m-d" }}
@@ -180,5 +180,5 @@
 {% block datatable_constructor %}
     {{ block.super }}
     config.ordering = true
-    config.order = [[1, 'desc']]
+    config.order = [[1, 'desc'], [2, 'desc'], [0, 'desc']]
 {% endblock %}


### PR DESCRIPTION
To make the events grouped and ordered more intuitively.
I.e. when sorting by date (newest first), the activation event of a sub should appear below the deactivation event of the same sub etc.