### PR TITLE
admin: Multiple Area coordinators

### DIFF
--- a/juntagrico/admin_sites.py
+++ b/juntagrico/admin_sites.py
@@ -1,0 +1,14 @@
+from django.contrib import admin
+from django.contrib.admin.apps import AdminConfig
+
+
+class JuntagricoAdminSite(admin.AdminSite):
+    def has_permission(self, request):
+        # give area coordinators access to admin
+        return request.user.is_active and (
+                request.user.is_staff or request.user.member.area_access.filter(can_modify_jobs=True).exists()
+        )
+
+
+class JuntagricoAdminConfig(AdminConfig):
+    default_site = 'juntagrico.admin_sites.JuntagricoAdminSite'

--- a/juntagrico/admins/__init__.py
+++ b/juntagrico/admins/__init__.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.contrib.admin.options import BaseModelAdmin
 from django.db.models import TextField
 from djrichtextfield.widgets import RichTextWidget
 from import_export.admin import ExportMixin
@@ -66,3 +67,44 @@ class SortableExportMixin(ExportMixin):
     """ Fix to make import-export and sortable admin work together.
     """
     change_list_template = 'adminsortable2/change_list.html'
+
+
+class AreaCoordinatorMixin(BaseModelAdmin):
+    # TODO: also show job contacts and job extras?
+    coordinator_permissions = ['view', 'add', 'change', 'delete']
+    path_to_area = 'pk'
+
+    def _has_permission(self, request, obj=None, access=None):
+        if access is None or access in self.coordinator_permissions:
+            area = {'area': self.get_area(obj)} if obj else {}
+            return request.user.member.area_access.filter(**area, can_modify_jobs=True).exists()
+        return False
+
+    def get_area(self, obj):
+        return obj
+
+    def has_module_permission(self, request):
+        return self._has_permission(request) or super().has_module_permission(request)
+
+    def has_view_permission(self, request, obj=None):
+        return self._has_permission(request, obj, 'view') or super().has_view_permission(request)
+
+    def has_add_permission(self, request):
+        return self._has_permission(request, None, 'add') or super().has_add_permission(request)
+
+    def has_change_permission(self, request, obj=None):
+        return self._has_permission(request, obj, 'change') or super().has_change_permission(request)
+
+    def has_delete_permission(self, request, obj=None):
+        return self._has_permission(request, obj, 'delete') or super().has_delete_permission(request)
+
+    def get_queryset(self, request):
+        if super().has_view_permission(request):
+            return super().get_queryset(request)
+        else:
+            allowed_areas = request.user.member.coordinated_areas.filter(coordinator_access__can_modify_jobs=True)
+            return super().get_queryset(request).filter(**{f'{self.path_to_area}__in': allowed_areas})
+
+
+def can_see_all(user, model):
+    return user.has_perm(f'juntagrico.view_{model}') or user.has_perm(f'juntagrico.change_{model}')

--- a/juntagrico/admins/area_admin.py
+++ b/juntagrico/admins/area_admin.py
@@ -1,4 +1,4 @@
-from adminsortable2.admin import SortableAdminMixin
+from adminsortable2.admin import SortableAdminMixin, SortableTabularInline
 from django.utils.safestring import mark_safe
 from polymorphic.admin import PolymorphicInlineSupportMixin
 from django.utils.translation import gettext as _
@@ -6,7 +6,23 @@ from django.contrib import admin
 
 from juntagrico.admins import RichTextAdmin
 from juntagrico.admins.inlines.contact_inline import ContactInline
+from juntagrico.entity.jobs import AreaCoordinator
 from juntagrico.util.admin import queryset_for_coordinator
+
+
+class AreaCoordinatorInline(SortableTabularInline):
+    model = AreaCoordinator
+    autocomplete_fields = ('member',)
+    min_num = 1
+    extra = 0
+
+    def get_formset(self, *args, **kwargs):
+        # validates, that at least min_num undeleted forms are sent
+        return super().get_formset(validate_min=True, *args, **kwargs)
+
+    def has_delete_permission(self, request, obj=None):
+        # only show delete option of there is more than 1 coordinator
+        return obj is not None and obj.coordinators.count() > 1
 
 
 class AreaAdmin(PolymorphicInlineSupportMixin, SortableAdminMixin, RichTextAdmin):
@@ -14,7 +30,7 @@ class AreaAdmin(PolymorphicInlineSupportMixin, SortableAdminMixin, RichTextAdmin
     raw_id_fields = ['coordinator']
     list_display = ['name', 'core', 'hidden', 'coordinator', 'auto_add_new_members', 'contacts_text']
     search_fields = ['name']
-    inlines = [ContactInline]
+    inlines = [AreaCoordinatorInline, ContactInline]
 
     @admin.display(description=_('Kontakt'))
     def contacts_text(self, instance):

--- a/juntagrico/admins/area_admin.py
+++ b/juntagrico/admins/area_admin.py
@@ -4,10 +4,9 @@ from polymorphic.admin import PolymorphicInlineSupportMixin
 from django.utils.translation import gettext as _
 from django.contrib import admin
 
-from juntagrico.admins import RichTextAdmin
+from juntagrico.admins import RichTextAdmin, AreaCoordinatorMixin
 from juntagrico.admins.inlines.contact_inline import ContactInline
 from juntagrico.entity.jobs import AreaCoordinator
-from juntagrico.util.admin import queryset_for_coordinator
 
 
 class AreaCoordinatorInline(SortableTabularInline):
@@ -25,22 +24,21 @@ class AreaCoordinatorInline(SortableTabularInline):
         return obj is not None and obj.coordinators.count() > 1
 
 
-class AreaAdmin(PolymorphicInlineSupportMixin, SortableAdminMixin, RichTextAdmin):
+class AreaAdmin(PolymorphicInlineSupportMixin, SortableAdminMixin, AreaCoordinatorMixin, RichTextAdmin):
     filter_horizontal = ['members']
     raw_id_fields = ['coordinator']
     list_display = ['name', 'core', 'hidden', 'coordinator', 'auto_add_new_members', 'contacts_text']
     search_fields = ['name']
     inlines = [AreaCoordinatorInline, ContactInline]
+    coordinator_permissions = ['view']
 
     @admin.display(description=_('Kontakt'))
     def contacts_text(self, instance):
         return mark_safe("<br>".join([str(c) for c in instance.contacts]))
 
-    def get_queryset(self, request):
-        return queryset_for_coordinator(self, request, 'coordinator')
-
-    def get_readonly_fields(self, request, obj=None):
-        if request.user.has_perm('juntagrico.is_area_admin') and (
-                not (request.user.is_superuser or request.user.has_perm('juntagrico.is_operations_group'))):
-            return ['name', 'core', 'hidden', 'coordinator']
-        return self.readonly_fields
+    def get_fields(self, request, obj=None):
+        if super(AreaCoordinatorMixin, self).has_view_permission(request):
+            return super().get_fields(request, obj)
+        else:
+            # limited access for area coordinators
+            return ['name', 'description']

--- a/juntagrico/admins/forms/job_copy_form.py
+++ b/juntagrico/admins/forms/job_copy_form.py
@@ -13,7 +13,55 @@ from juntagrico.entity.jobs import RecuringJob
 from juntagrico.util.temporal import weekday_choices
 
 
+def collect_contacts(formsets):
+    """collect contacts from formsets
+    """
+    contacts = []
+    if formsets and len(formsets) >= 1:
+        for contact_form in formsets[0].forms:
+            if not contact_form.cleaned_data['DELETE']:
+                contacts.append(contact_form.instance.copy())
+        # excepted by ModelAdmin
+        formsets[0].new_objects = []
+        formsets[0].changed_objects = []
+        formsets[0].deleted_objects = []
+    return contacts
+
+
+class OnlyFutureJobForm(forms.ModelForm):
+    def clean_time(self):
+        time = self.cleaned_data['time']
+        if time <= timezone.now():
+            raise ValidationError(_('Neue Jobs können nicht in der Vergangenheit liegen.'))
+        return time
+
+
 class JobCopyForm(forms.ModelForm):
+    class Meta:
+        model = RecuringJob
+        exclude = ['canceled']
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.initial['time'] = None
+
+    def save(self, commit=True):
+        self.instance.pk = None
+        self.instance.id = None
+        return super().save(commit)
+
+    def save_related(self, formsets):
+        # copy contacts
+        self.instance.save()
+        for contact in collect_contacts(formsets):
+            self.instance.contact_set.add(contact, bulk=False)
+
+
+class JobCopyToFutureForm(JobCopyForm, OnlyFutureJobForm):
+    pass
+
+
+class JobMassCopyForm(forms.ModelForm):
     class Meta:
         model = RecuringJob
         fields = []
@@ -72,17 +120,8 @@ class JobCopyForm(forms.ModelForm):
         return newjob
 
     def save_related(self, formsets):
-        # collect contacts from formsets
-        contacts = []
-        if formsets and len(formsets) >= 1:
-            for contact_form in formsets[0].forms:
-                if not contact_form.cleaned_data['DELETE']:
-                    contacts.append(contact_form.instance.copy())
-            # excepted by ModelAdmin
-            formsets[0].new_objects = []
-            formsets[0].changed_objects = []
-            formsets[0].deleted_objects = []
         # save and apply contacts
+        contacts = collect_contacts(formsets)
         for job in self.new_jobs:
             job.save()
             for contact in contacts:
@@ -114,7 +153,7 @@ class JobCopyForm(forms.ModelForm):
         return res
 
 
-class JobCopyToFutureForm(JobCopyForm):
+class JobMassCopyToFutureForm(JobMassCopyForm):
     def clean(self):
         cleaned_data = super().clean()
         if self.cleaned(cleaned_data) and self.get_datetimes(cleaned_data)[0] <= timezone.now():

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -1,7 +1,5 @@
 from datetime import timedelta, datetime, date
 
-from django import forms
-from django.core.exceptions import ValidationError
 from django.urls import path, reverse
 from django.contrib import admin
 from django.http import HttpResponseRedirect
@@ -11,28 +9,15 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from polymorphic.admin import PolymorphicInlineSupportMixin
 
-from juntagrico.admins import RichTextAdmin, OverrideFieldQuerySetMixin
+from juntagrico.admins import RichTextAdmin, AreaCoordinatorMixin, can_see_all
 from juntagrico.admins.admin_decorators import single_element_action
 from juntagrico.admins.filters import FutureDateTimeFilter
-from juntagrico.admins.forms.job_copy_form import JobCopyForm, JobCopyToFutureForm
+from juntagrico.admins.forms.job_copy_form import JobMassCopyForm, JobMassCopyToFutureForm, \
+    OnlyFutureJobForm, JobCopyForm, JobCopyToFutureForm
 from juntagrico.admins.inlines.assignment_inline import AssignmentInline
 from juntagrico.admins.inlines.contact_inline import ContactInline
-from juntagrico.dao.jobtypedao import JobTypeDao
 from juntagrico.entity.jobs import RecuringJob, JobType
 from juntagrico.templatetags.juntagrico.common import richtext
-from juntagrico.util.admin import formfield_for_coordinator, queryset_for_coordinator
-
-
-def can_edit_past_jobs(request):
-    return request.user.is_superuser or request.user.has_perm('juntagrico.can_edit_past_jobs')
-
-
-class OnlyFutureJobAdminForm(forms.ModelForm):
-    def clean_time(self):
-        time = self.cleaned_data['time']
-        if time <= timezone.now():
-            raise ValidationError(_('Neue Jobs können nicht in der Vergangenheit liegen.'))
-        return time
 
 
 def type_div(field, value=None):
@@ -45,9 +30,24 @@ def type_div(field, value=None):
     )
 
 
-class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTextAdmin):
-    fields = ('type', 'time', ('duration_override', 'type_duration'), 'multiplier', ('slots', 'infinite_slots', 'free_slots'),
-              'type_description', 'additional_description', 'pinned', 'canceled')
+class OnlyFutureJobMixin(admin.ModelAdmin):
+    def has_change_permission(self, request, obj=None):
+        return (obj is None or obj.check_if(request.user).can_modify()) and super().has_change_permission(request, obj)
+
+    def has_delete_permission(self, request, obj=None):
+        return (obj is None or obj.check_if(request.user).can_modify()) and super().has_delete_permission(request, obj)
+
+    def get_form(self, request, obj=None, **kwds):
+        if not request.user.has_perm('juntagrico.can_edit_past_jobs'):
+            kwds['form'] = OnlyFutureJobForm
+        return super().get_form(request, obj, **kwds)
+
+
+class JobCopy(admin.ModelAdmin):
+    """ All overrides for the mass copy view
+    """
+    copy_fields = ('type', 'time', ('duration_override', 'type_duration'), 'multiplier', ('slots', 'infinite_slots'),
+              'type_description', 'additional_description', 'pinned')
     copy_fieldsets = [
         (None, {'fields': [
             'type', ('duration_override', 'type_duration'), 'multiplier', ('slots', 'infinite_slots'),
@@ -57,6 +57,95 @@ class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTe
             'new_time', 'start_date', 'end_date', 'weekdays', 'weekly'
         ]}),
     ]
+    copy_readonly_fields = ['type_description', 'type_duration']
+
+    def get_urls(self):
+        urls = super().get_urls()
+        my_urls = [
+            path('<str:object_id>/mass_copy/', self.admin_site.admin_view(self.mass_copy_job_view), name='action-mass-copy-job'),
+            path('<str:object_id>/copy/', self.admin_site.admin_view(self.change_view), {
+                'extra_context': {
+                    'title': _('Job kopieren'),
+                    'show_save_and_continue': False,
+                    'show_save_and_add_another': False,
+                    'show_delete': False,
+                }
+            }, name='action-copy-job'),
+        ]
+        return my_urls + urls
+
+    def mass_copy_job_view(self, request, object_id):
+        return self.change_view(request, object_id, extra_context={
+            'title': _('Job mehrfach kopieren'),
+            'show_save_and_continue': False,
+            'show_save_and_add_another': False,
+            'show_delete': False,
+        })
+
+    @staticmethod
+    def is_mass_copy_view(request):
+        return request.resolver_match.url_name == 'action-mass-copy-job'
+
+    @staticmethod
+    def is_copy_view(request):
+        return request.resolver_match.url_name == 'action-copy-job'
+
+    def get_form(self, request, obj=None, **kwds):
+        # return forms for mass copy
+        if self.is_mass_copy_view(request):
+            if request.user.has_perm('juntagrico.can_edit_past_jobs'):
+                kwds['form'] = JobMassCopyForm
+            else:
+                kwds['form'] = JobMassCopyToFutureForm
+        elif self.is_copy_view(request):
+            if request.user.has_perm('juntagrico.can_edit_past_jobs'):
+                kwds['form'] = JobCopyForm
+            else:
+                kwds['form'] = JobCopyToFutureForm
+        return super().get_form(request, obj, **kwds)
+
+    def has_change_permission(self, request, obj=None):
+        can_copy = self.is_mass_copy_view(request) and super().has_add_permission(request)
+        return can_copy or super().has_change_permission(request, obj)
+
+    def get_fields(self, request, obj=None):
+        if self.is_mass_copy_view(request):
+            return None
+        elif self.is_copy_view(request):
+            return self.copy_fields
+        return super().get_fields(request, obj)
+
+    def get_fieldsets(self, request, obj=None):
+        if self.is_mass_copy_view(request):
+            return self.copy_fieldsets
+        return super().get_fieldsets(request, obj)
+
+    def get_readonly_fields(self, request, obj=None):
+        if self.is_mass_copy_view(request):
+            return self.copy_readonly_fields  # special case for mass job copy action
+        return super().get_readonly_fields(request, obj)
+
+    def get_inlines(self, request, obj):
+        if self.is_mass_copy_view(request) or self.is_copy_view(request):
+            return [ContactInline]  # special case for mass job copy action
+        return super().get_inlines(request, obj)
+
+    def save_related(self, request, form, formsets, change):
+        if self.is_mass_copy_view(request) or self.is_copy_view(request):
+            form.save_related(formsets)
+        else:
+            super().save_related(request, form, formsets, change)
+
+    def response_change(self, request, obj):
+        if self.is_copy_view(request):
+            # show new job on page
+            return HttpResponseRedirect(reverse('job', args=[obj.id]))
+        return super().response_change(request, obj)
+
+
+class JobAdmin(PolymorphicInlineSupportMixin, AreaCoordinatorMixin, RichTextAdmin, OnlyFutureJobMixin, JobCopy):
+    fields = ('type', 'time', ('duration_override', 'type_duration'), 'multiplier', ('slots', 'infinite_slots', 'free_slots'),
+              'type_description', 'additional_description', 'pinned', 'canceled')
     list_display = ['__str__', 'type', 'time', 'slots', 'free_slots']
     list_filter = (('type__activityarea', admin.RelatedOnlyFieldListFilter), ('time', FutureDateTimeFilter))
     actions = ['copy_job', 'mass_copy_job']
@@ -65,7 +154,7 @@ class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTe
     autocomplete_fields = ['type']
     inlines = [ContactInline, AssignmentInline]
     readonly_fields = ['free_slots', 'type_description', 'type_duration']
-    copy_readonly_fields = ['type_description', 'type_duration']
+    path_to_area = 'type__activityarea'
 
     @admin.display(description=_('Beschreibung der Jobart'))
     def type_description(self, instance):
@@ -76,40 +165,6 @@ class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTe
     def type_duration(self, instance):
         return type_div('duration', instance.type.default_duration if instance.type_id else None)
 
-    def has_change_permission(self, request, obj=None):
-        return (self.is_copy_view(request) or obj is None or obj.can_modify(request)
-                ) and super().has_change_permission(request, obj)
-
-    def has_delete_permission(self, request, obj=None):
-        return (self.is_copy_view(request) or obj is None or obj.can_modify(request)
-                ) and super().has_delete_permission(request, obj)
-
-    def get_fields(self, request, obj=None):
-        if self.is_copy_view(request):
-            return None
-        return super().get_fields(request, obj)
-
-    def get_fieldsets(self, request, obj=None):
-        if self.is_copy_view(request):
-            return self.copy_fieldsets
-        return super().get_fieldsets(request, obj)
-
-    def get_readonly_fields(self, request, obj=None):
-        if self.is_copy_view(request):
-            return self.copy_readonly_fields  # special case for mass job copy action
-        return super().get_readonly_fields(request, obj)
-
-    def get_inlines(self, request, obj):
-        if self.is_copy_view(request):
-            return [ContactInline]  # special case for mass job copy action
-        return super().get_inlines(request, obj)
-
-    def save_related(self, request, form, formsets, change):
-        if self.is_copy_view(request):
-            form.save_related(formsets)
-        else:
-            super().save_related(request, form, formsets, change)
-
     @admin.action(description=_('Job mehrfach kopieren...'))
     @single_element_action('Genau 1 Job auswählen!')
     def mass_copy_job(self, request, queryset):
@@ -118,56 +173,27 @@ class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTe
 
     @admin.action(description=_('Jobs kopieren'))
     def copy_job(self, request, queryset):
-        for inst in queryset.all():
-            time = inst.time
-            if not can_edit_past_jobs(request) and time <= timezone.now():
+        for instance in queryset.all():
+            time = instance.time
+            if not request.user.has_perm('juntagrico.can_edit_past_jobs') and time <= timezone.now():
                 # create copy in future if job is in past and member can't edit past jobs
                 time = datetime.combine(date.today() + timedelta(7), time.time())
-            newjob = RecuringJob(type=inst.type, slots=inst.slots, time=time)
-            newjob.save()
+            new_job = RecuringJob(type=instance.type, slots=instance.slots, time=time)
+            new_job.save()
 
-    def get_form(self, request, obj=None, **kwds):
-        # return forms for mass copy
-        if self.is_copy_view(request):
-            if can_edit_past_jobs(request):
-                kwds['form'] = JobCopyForm
-            else:
-                kwds['form'] = JobCopyToFutureForm
-        # or return normal edit forms
-        elif not can_edit_past_jobs(request):
-            kwds['form'] = OnlyFutureJobAdminForm
-        return super().get_form(request, obj, **kwds)
+    def get_area(self, obj):
+        return obj.type.activityarea
 
-    def get_urls(self):
-        urls = super().get_urls()
-        my_urls = [
-            path('mass_copy_job/<str:jobid>/',
-                 self.admin_site.admin_view(self.copy_job_view), name='action-mass-copy-job')
-        ]
-        return my_urls + urls
-
-    @staticmethod
-    def is_copy_view(request):
-        return request.resolver_match.url_name == 'action-mass-copy-job'
-
-    def copy_job_view(self, request, jobid):
-        return self.change_view(request, jobid, extra_context={
-            'title': _('Job mehrfach kopieren'),
-            'show_save_and_continue': False,
-            'show_save_and_add_another': False,
-            'show_delete': False,
-        })
-
-    def get_queryset(self, request):
-        return queryset_for_coordinator(self, request, 'type__activityarea__coordinator')
-
-    def get_type_queryset(self, request, obj):
-        visible_by_coordinator = formfield_for_coordinator(
-            request, None, None, 'juntagrico.is_area_admin',
-            JobTypeDao.visible_types_by_coordinator,
-            queryset=JobTypeDao.visible_types()
-        )['queryset']
-        return (JobType.objects.filter(recuringjob=obj) | visible_by_coordinator).distinct()
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        # used for form validation
+        if db_field.name == 'type':
+            user = request.user
+            if not can_see_all(user, 'jobtype'):
+                kwargs["queryset"] = JobType.objects.filter(
+                    activityarea__coordinator_access__member__user=user,
+                    activityarea__coordinator_access__can_modify_jobs=True
+                )
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     class Media:
         js = ["juntagrico/js/job_admin.js"]

--- a/juntagrico/admins/job_type_admin.py
+++ b/juntagrico/admins/job_type_admin.py
@@ -4,21 +4,36 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from polymorphic.admin import PolymorphicInlineSupportMixin
 
-from juntagrico.admins import RichTextAdmin, OverrideFieldQuerySetMixin
+from juntagrico.admins import RichTextAdmin, OverrideFieldQuerySetMixin, AreaCoordinatorMixin, can_see_all
 from juntagrico.admins.inlines.contact_inline import ContactInline
 from juntagrico.admins.inlines.job_extra_inline import JobExtraInline
-from juntagrico.dao.activityareadao import ActivityAreaDao
 from juntagrico.dao.assignmentdao import AssignmentDao
 from juntagrico.dao.jobdao import JobDao
 from juntagrico.dao.jobextradao import JobExtraDao
-from juntagrico.dao.jobtypedao import JobTypeDao
-from juntagrico.entity.jobs import OneTimeJob
+from juntagrico.entity.jobs import OneTimeJob, ActivityArea
 from juntagrico.entity.location import Location
-from juntagrico.util.admin import formfield_for_coordinator, queryset_for_coordinator
 from juntagrico.util.models import attribute_copy
 
 
-class JobTypeAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTextAdmin):
+class JobTypeBaseAdmin(AreaCoordinatorMixin):
+    path_to_area = 'activityarea'
+
+    def get_area(self, obj):
+        return obj.activityarea
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        # used for form validation
+        if db_field.name == 'activityarea':
+            user = request.user
+            if not can_see_all(user, 'activityarea'):
+                kwargs["queryset"] = ActivityArea.objects.filter(
+                    coordinator_access__member__user=user,
+                    coordinator_access__can_modify_jobs=True
+                )
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+
+class JobTypeAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTextAdmin, JobTypeBaseAdmin):
     fields = ('name', 'displayed_name', 'activityarea', 'location', 'default_duration', 'description', 'visible')
     list_display = ['__str__', 'default_duration', 'location', 'contacts_text', 'visible', 'last_used']
     list_filter = (('activityarea', admin.RelatedOnlyFieldListFilter), 'visible')
@@ -76,25 +91,9 @@ class JobTypeAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, Ri
         return Location.objects.exclude(Q(visible=False), ~Q(jobtype=obj))
 
     def get_queryset(self, request):
-        qs = queryset_for_coordinator(self, request, 'activityarea__coordinator')
-        if request.resolver_match.view_name != 'admin:autocomplete':
+        qs = super().get_queryset(request)
+        if request.resolver_match.view_name == 'admin:autocomplete':
+            qs = qs.filter(visible=True)
+        else:
             qs = qs.annotate(last_used=Max('recuringjob__time'))
         return qs
-
-    def get_search_results(self, request, queryset, search_term):
-        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
-        if 'autocomplete' in request.path and request.GET.get('model_name') == 'recuringjob' and request.GET.get(
-                'field_name') == 'type':
-            queryset = queryset.filter(visible=True)
-            if request.user.has_perm('juntagrico.is_area_admin') and (
-                    not (request.user.is_superuser or request.user.has_perm('juntagrico.is_operations_group'))):
-                queryset = queryset.intersection(JobTypeDao.visible_types_by_coordinator(request.user.member))
-        return queryset, use_distinct
-
-    def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        kwargs = formfield_for_coordinator(request,
-                                           db_field.name,
-                                           'activityarea',
-                                           'juntagrico.is_area_admin',
-                                           ActivityAreaDao.areas_by_coordinator)
-        return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/juntagrico/admins/location_admin.py
+++ b/juntagrico/admins/location_admin.py
@@ -45,3 +45,19 @@ class LocationAdmin(SortableAdminMixin, RichTextAdmin):
                           locations=queryset,
                           form=form
                       ))
+
+    def get_queryset(self, request):
+        # for autocomplete and coordinators only show visible locations
+        # TODO: backport autocomplete filter to 1.7
+        if super().has_view_permission(request) and request.resolver_match.view_name != 'admin:autocomplete':
+            return super().get_queryset(request)
+        return super().get_queryset(request).filter(visible=True)
+
+    def has_view_permission(self, request, obj=None):
+        return (
+            super().has_view_permission(request, obj) or (
+                # area coordinators can see visible locations
+                request.user.member.area_access.filter(can_modify_jobs=True).exists()
+                and (obj is None or obj.visible)
+            )
+        )

--- a/juntagrico/admins/one_time_job_admin.py
+++ b/juntagrico/admins/one_time_job_admin.py
@@ -8,19 +8,20 @@ from juntagrico.admins.filters import FutureDateTimeFilter
 from juntagrico.admins.inlines.assignment_inline import AssignmentInline
 from juntagrico.admins.inlines.contact_inline import ContactInline
 from juntagrico.admins.inlines.job_extra_inline import JobExtraInline
-from juntagrico.dao.activityareadao import ActivityAreaDao
+from juntagrico.admins.job_admin import OnlyFutureJobMixin
+from juntagrico.admins.job_type_admin import JobTypeBaseAdmin
 from juntagrico.dao.assignmentdao import AssignmentDao
 from juntagrico.entity.jobs import JobType, RecuringJob
 from juntagrico.entity.location import Location
-from juntagrico.util.admin import formfield_for_coordinator, queryset_for_coordinator
 from juntagrico.util.models import attribute_copy
 
 
-class OneTimeJobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTextAdmin):
+class OneTimeJobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTextAdmin, OnlyFutureJobMixin,
+                      JobTypeBaseAdmin):
     fields = ('name', 'displayed_name', 'activityarea', 'location', 'time', 'default_duration', 'multiplier',
               ('slots', 'infinite_slots', 'free_slots'), 'description', 'pinned', 'canceled')
     list_display = ['__str__', 'time', 'slots', 'free_slots']
-    list_filter = ('activityarea', ('time', FutureDateTimeFilter))
+    list_filter = (('activityarea', admin.RelatedOnlyFieldListFilter), ('time', FutureDateTimeFilter))
     actions = ['transform_job']
     search_fields = ['name', 'activityarea__name', 'time']
     exclude = ['reminder_sent']
@@ -28,12 +29,6 @@ class OneTimeJobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin,
 
     inlines = [ContactInline, AssignmentInline, JobExtraInline]
     readonly_fields = ['free_slots']
-
-    def has_change_permission(self, request, obj=None):
-        return (obj is None or obj.can_modify(request)) and super().has_change_permission(request, obj)
-
-    def has_delete_permission(self, request, obj=None):
-        return (obj is None or obj.can_modify(request)) and super().has_delete_permission(request, obj)
 
     @admin.action(description=_('EinzelJobs in Jobart konvertieren'))
     def transform_job(self, request, queryset):
@@ -56,14 +51,3 @@ class OneTimeJobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin,
 
     def get_location_queryset(self, request, obj):
         return Location.objects.exclude(Q(visible=False), ~Q(onetimejob=obj))
-
-    def get_queryset(self, request):
-        return queryset_for_coordinator(self, request, 'activityarea__coordinator')
-
-    def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        kwargs = formfield_for_coordinator(request,
-                                           db_field.name,
-                                           'activityarea',
-                                           'juntagrico.is_area_admin',
-                                           ActivityAreaDao.areas_by_coordinator)
-        return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -76,6 +76,7 @@ class AreaCoordinator(JuntagricoBaseModel):
     can_modify_area = models.BooleanField(_('Kann Beschreibung ändern'), default=True)
     can_view_member = models.BooleanField(_('Kann {0} sehen').format(Config.vocabulary('member_pl')), default=True)
     can_contact_member = models.BooleanField(_('Kann {0} kontaktieren').format(Config.vocabulary('member_pl')), default=True)
+    can_remove_member = models.BooleanField(_('Kann {0} entfernen').format(Config.vocabulary('member_pl')), default=True)
     can_modify_jobs = models.BooleanField(_('Kann Jobs verwalten'), default=True)
     can_modify_assignments = models.BooleanField(_('Kann Einsatzanmeldungen verwalten'), default=True)
     sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)

--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -27,6 +27,8 @@ class ActivityArea(JuntagricoBaseModel):
         _('versteckt'), default=False,
         help_text=_('Nicht auf der "Tätigkeitsbereiche"-Seite anzeigen. Einsätze bleiben sichtbar.'))
     coordinator = models.ForeignKey('Member', on_delete=models.PROTECT, verbose_name=_('KoordinatorIn'))
+    coordinators = models.ManyToManyField('Member', verbose_name=_('Koordinatoren'), through='AreaCoordinator',
+                                          related_name='coordinated_areas')
     members = models.ManyToManyField(
         'Member', related_name='areas', blank=True, verbose_name=Config.vocabulary('member_pl'))
     sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)
@@ -67,6 +69,24 @@ class ActivityArea(JuntagricoBaseModel):
         permissions = (
             ('is_area_admin', _('Benutzer ist TätigkeitsbereichskoordinatorIn')),)
 
+
+class AreaCoordinator(JuntagricoBaseModel):
+    area = models.ForeignKey(ActivityArea, on_delete=models.CASCADE)
+    member = models.ForeignKey('Member', on_delete=models.CASCADE)
+    can_modify_area = models.BooleanField(_('Kann Beschreibung ändern'), default=True)
+    can_view_member = models.BooleanField(_('Kann {0} sehen').format(Config.vocabulary('member_pl')), default=True)
+    can_contact_member = models.BooleanField(_('Kann {0} kontaktieren').format(Config.vocabulary('member_pl')), default=True)
+    can_modify_jobs = models.BooleanField(_('Kann Jobs verwalten'), default=True)
+    can_modify_assignments = models.BooleanField(_('Kann Einsatzanmeldungen verwalten'), default=True)
+    sort_order = models.PositiveIntegerField(_('Reihenfolge'), default=0, blank=False, null=False)
+
+    class Meta:
+        verbose_name = _('Koordinator')
+        verbose_name_plural = _('Koordinatoren')
+        ordering = ['sort_order']
+        constraints = [
+            models.UniqueConstraint(fields=['area', 'member'], name='unique_area_member'),
+        ]
 
 class JobExtraType(JuntagricoBaseModel):
     '''

--- a/juntagrico/fixtures/test/areas.json
+++ b/juntagrico/fixtures/test/areas.json
@@ -173,5 +173,23 @@
         "object_id": 2,
         "sort_order": 0
     }
+},
+{
+    "model": "juntagrico.areacoordinator",
+    "pk": 1,
+    "fields": {
+        "area": 1,
+        "member": 21,
+        "can_view_member": true
+    }
+},
+{
+    "model": "juntagrico.areacoordinator",
+    "pk": 2,
+    "fields": {
+        "area": 2,
+        "member": 21,
+        "can_view_member": true
+    }
 }
 ]

--- a/juntagrico/forms.py
+++ b/juntagrico/forms.py
@@ -16,12 +16,13 @@ from django.utils.safestring import mark_safe
 from django.utils.text import format_lazy
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
+from djrichtextfield.widgets import RichTextWidget
 
 from juntagrico.config import Config
 from juntagrico.dao.memberdao import MemberDao
 from juntagrico.dao.subscriptionproductdao import SubscriptionProductDao
 from juntagrico.dao.subscriptiontypedao import SubscriptionTypeDao
-from juntagrico.entity.jobs import Assignment, Job, JobExtra
+from juntagrico.entity.jobs import Assignment, Job, JobExtra, ActivityArea
 from juntagrico.entity.subtypes import SubscriptionType
 from juntagrico.models import Member, Subscription
 from juntagrico.signals import subscribed, assignment_changed
@@ -674,6 +675,26 @@ class GenerateListForm(Form):
             del self.fields['future']
         self.helper = FormHelper()
         self.helper.add_input(Submit('submit', _('Listen Erzeugen')))
+
+
+class AreaDescriptionForm(ModelForm):
+    class Meta:
+        model = ActivityArea
+        fields = ['description']
+        labels = {'description': ''}
+        if Config.using_richtext():
+            widgets = {'description': RichTextWidget()}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_class = 'form-horizontal'
+        self.helper.layout = Layout(
+            'description',
+            FormActions(
+                Submit('submit', _('Speichern')),
+            ),
+        )
 
 
 class JobSubscribeForm(Form):

--- a/juntagrico/templates/area.html
+++ b/juntagrico/templates/area.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load crispy_forms_tags %}
 {% load i18n %}
 {% load static %}
 {% load juntagrico.common %}
@@ -9,13 +10,37 @@
     </h3>
 {% endblock %}
 {% block content %}
+    <div class="row mb-3 no-gutters">
+        <div class="offset-md-3 col-md-9">
+            <span class="switch switch-sm">
+                <input type="checkbox" class="switch" value="{{ area.id }}"
+                       id="area{{ area.id }}" name="area{{ area.id }}"{% if area_checked %} checked="checked"{% endif %}/>
+                <label for="area{{ area.id }}">
+                    {% trans "Mitmachen" %}
+                </label>
+            </span>
+        </div>
+    </div>
     <div class="row mb-3">
         <div class="col-md-3">
             {% trans "Beschreibung" %}:
         </div>
-        <div class="col-md-9">
+        <div class="col-md-9 description-show">
             {{ area.description|richtext|safe }}
+            {% if edit_form %}
+                <div class="mt-3">
+                    <a href="#" id="edit_description" class="btn btn-primary">
+                        <i class="fa fa-pencil mr-1"></i>
+                        {% trans "Beschreibung ändern" %}
+                    </a>
+                </div>
+            {% endif %}
         </div>
+        {% if edit_form %}
+            <div class="col-md-9 description-edit d-none">
+                {% crispy edit_form %}
+            </div>
+        {% endif %}
     </div>
     <div class="row mb-4">
         <div class="col-md-3">
@@ -27,16 +52,20 @@
             {% endfor %}
         </div>
     </div>
-    <div class="row mb-3 no-gutters">
-        <div class="offset-md-3 col-md-9">
-            <span class="switch switch-sm">
-                <input type="checkbox" class="switch" value="{{ area.id }}" id="area{{ area.id }}" name="area{{ area.id }}"{% if area_checked %}checked="checked"{% endif %}/>
-                <label for="area{{ area.id }}">
-                    {% trans "Mitmachen" %}
-                </label>
-            </span>
+    {% if can_view_member %}
+        <div class="row mb-4">
+            <div class="col-md-3">
+                {{ vocabulary.member_pl }}:
+            </div>
+            <div class="col-md-9">
+                <span class="mr-3">{{ area.members.count|default:_('Keine') }}</span>
+                <a href="{% url 'manage-area-member' area.id %}" class="btn btn-outline-primary">
+                    <i class="fa fa-eye mr-1"></i>
+                    {% trans "Anzeigen" %}
+                </a>
+            </div>
         </div>
-    </div>
+    {% endif %}
     <div class="row mb-3">
         <div class="col-md-12">
             <h4>
@@ -59,6 +88,14 @@
     <script type="text/javascript">
         $(function() {
             $("#filter-table").DataTable({"searching": false});
+
+            $("#edit_description").on("click", function(e) {
+                $(this).hide();
+                $(".description-show").hide();
+                $(".description-edit").removeClass("d-none");
+                e.preventDefault();
+                return false;
+            })
         })
     </script>
     {% include 'snippets/scripts/area_slider.html' %}

--- a/juntagrico/templates/area.html
+++ b/juntagrico/templates/area.html
@@ -75,6 +75,7 @@
     </div>
     <div class="row mb-3">
         <div class="col-md-12">
+
             {% include "snippets/snippet_jobs.html" %}
             {% if jobs|length <= 0 %}
                 {% trans "Keine Einsätze ausgeschrieben" %}

--- a/juntagrico/templates/areas.html
+++ b/juntagrico/templates/areas.html
@@ -65,9 +65,11 @@
             <div class="col-md-12">
                 {% block coordinated_areas %}
                     <h4>{% trans "Von dir koordiniert" %}</h4>
-                    {% for area in coordinated_areas %}
-                        <a href="{% url 'area' area.id %}">{{ area }}</a>
-                    {% endfor %}
+                        <ul>
+                            {% for area in coordinated_areas %}
+                                <li><a href="{% url 'area' area.id %}">{{ area }}</a></li>
+                            {% endfor %}
+                        </ul>
                 {% endblock %}
             </div>
         </div>

--- a/juntagrico/templates/areas.html
+++ b/juntagrico/templates/areas.html
@@ -2,11 +2,13 @@
 {% load i18n %}
 {% load static %}
 {% load juntagrico.config %}
+
 {% block page_title %}
     <h3>
         {% trans "Mitarbeit" %}
     </h3>
 {% endblock %}
+
 {% block content %}
     {% enriched_organisation "D" as v_d_enriched_organisation %}
     <div class="row">
@@ -57,7 +59,21 @@
             {% endfor %}
         </div>
     </div>
+
+    {% if coordinated_areas %}
+        <div class="row mt-5">
+            <div class="col-md-12">
+                {% block coordinated_areas %}
+                    <h4>{% trans "Von dir koordiniert" %}</h4>
+                    {% for area in coordinated_areas %}
+                        <a href="{% url 'area' area.id %}">{{ area }}</a>
+                    {% endfor %}
+                {% endblock %}
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
+
 {% block scripts %}
     {% include 'snippets/scripts/area_slider.html' %}
 {% endblock %}

--- a/juntagrico/templates/job.html
+++ b/juntagrico/templates/job.html
@@ -8,12 +8,6 @@
 {% block page_title %}
     <h3>
         {{ job.type.get_name }}
-        {% if edit_url.strip %}
-         <a href="{{ edit_url }}" class="edit">
-            <i class="fas fa-pen">
-            </i>
-        </a>
-        {% endif %}
     </h3>
 {% endblock %}
 
@@ -36,6 +30,47 @@
 
 {% block content %}
     {% vocabulary "assignment_pl" as v_assignment_pl %}
+    {% block admin_actions %}
+        {% if edit_url.strip or can_copy or can_cancel %}
+            <div class="row pb-4">
+                <div class="col-md-12">
+                    {% if edit_url.strip %}
+                        <a href="{{ edit_url }}" class="btn btn-primary">
+                            <i class="fas fa-pen mr-1"></i>
+                            {% trans "Einsatz bearbeiten" %}
+                        </a>
+                    {% endif %}
+
+                    {% if can_copy %}
+                        <div class="btn-group">
+                            <a href="{% url 'admin:action-copy-job' job.id %}" type="button" class="btn btn-outline-primary">
+                                <i class="fa-solid fa-copy"></i>
+                                {% trans "Einsatz kopieren" %}
+                            </a>
+                            <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split"
+                                    data-toggle="dropdown" data-reference="parent" aria-expanded="false">
+                                <span class="sr-only">{% trans "Dropdown öffnen" %}</span>
+                            </button>
+                            <div class="dropdown-menu">
+                                <a class="dropdown-item" href="{% url 'admin:action-mass-copy-job' job.id %}">
+                                    {% trans "Mehrfach kopieren" %}
+                                </a>
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    {% if can_cancel %}
+                        <a href="{% url 'job-cancel' job.id %}" class="btn btn-outline-danger"
+                        onclick="return confirm('{% trans "Bist du sicher, dass du diesen Einsatz absagen möchtest?" %}')">
+                            <i class="fas fa-ban mr-1"></i>
+                            {% trans "Einsatz absagen" %}
+                        </a>
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
+    {% endblock %}
+
     {% block time %}
         <div class="row pb-4">
             <div class="col-md-3">

--- a/juntagrico/templates/juntagrico/manage/member/show.html
+++ b/juntagrico/templates/juntagrico/manage/member/show.html
@@ -42,23 +42,25 @@
         </thead>
         <tfoot>
             <tr>
-                <th>
-                    {% trans "Kontakt" %}
-                </th>
-                {% if not hide_areas %}
+                {% block list_foot %}
                     <th>
-                        {% trans "Tätigkeitsbereiche" %}
+                        {% trans "Kontakt" %}
                     </th>
-                {% endif %}
-                <th>
-                    {% vocabulary "subscription" %}
-                </th>
-                <th>
-                    {% trans "Inhalt" %}
-                </th>
-                <th>
-                    {% vocabulary "depot" %}
-                </th>
+                    {% if not hide_areas %}
+                        <th>
+                            {% trans "Tätigkeitsbereiche" %}
+                        </th>
+                    {% endif %}
+                    <th>
+                        {% vocabulary "subscription" %}
+                    </th>
+                    <th>
+                        {% trans "Inhalt" %}
+                    </th>
+                    <th>
+                        {% vocabulary "depot" %}
+                    </th>
+                {% endblock %}
             </tr>
         </tfoot>
         <tbody>

--- a/juntagrico/templates/juntagrico/manage/member/show_for_area.html
+++ b/juntagrico/templates/juntagrico/manage/member/show_for_area.html
@@ -1,0 +1,43 @@
+{% extends "./show.html" %}
+{% load i18n %}
+{% load static %}
+{% load juntagrico.config %}
+{% load juntagrico.snippets %}
+
+
+{% block list_head %}
+    <th class="filter">
+        {% trans "Kontakt" %}
+    </th>
+    {% if can_remove_member %}
+        <th>
+            {% trans "Aktionen" %}
+        </th>
+    {% endif %}
+{% endblock %}
+
+{% block list_foot %}
+    <th>
+        {% trans "Kontakt" %}
+    </th>
+    {% if can_remove_member %}
+        <th>
+            {% trans "Aktionen" %}
+        </th>
+    {% endif %}
+{% endblock %}
+
+{% block list_entry %}
+    <td>
+        {# TODO: display email and phone number in own column #}
+        {% include './snippets/display_linked.html' %}
+    </td>
+    {% if can_remove_member %}
+        <td>
+            <a href="{% url 'manage-area-member-remove' area.id member.id %}" class="btn btn-outline-danger"
+               onclick="return confirm('{% trans "Bist du sicher?" %}')">
+                {% trans "Entfernen" %}
+            </a>
+        </td>
+    {% endif %}
+{% endblock %}

--- a/juntagrico/templates/juntagrico/manage/member/snippets/phone_linked.html
+++ b/juntagrico/templates/juntagrico/manage/member/snippets/phone_linked.html
@@ -1,6 +1,8 @@
-{% if member.mobile_phone %}
-    <a href="tel:{{ member.mobile_phone }}" class="phone-number">{{ member.mobile_phone }}</a>
-{% endif %}
-{% if member.phone %}
-    <a href="tel:{{ member.phone }}" class="phone-number">{{ member.phone }}</a>
+{% if can_see_phone_numbers or perms.juntagrico.view_member or perms.juntagrico.change_member %}
+    {% if member.mobile_phone %}
+        <a href="tel:{{ member.mobile_phone }}" class="phone-number">{{ member.mobile_phone }}</a>
+    {% endif %}
+    {% if member.phone %}
+        <a href="tel:{{ member.phone }}" class="phone-number">{{ member.phone }}</a>
+    {% endif %}
 {% endif %}

--- a/juntagrico/templates/juntagrico/manage/member/snippets/toggle_buttons.html
+++ b/juntagrico/templates/juntagrico/manage/member/snippets/toggle_buttons.html
@@ -1,13 +1,17 @@
 {% load i18n %}
 <div class="toggle-button-container mt-3 mb-3">
-    <span class="switch switch-sm">
-        <input class="switch toggle-display" type="checkbox" id="show_emails" data-filter=".email" checked="checked">
-        <label for="show_emails">{% trans "E-Mail-Adressen anzeigen" %}</label>
-    </span>
-    <span class="switch switch-sm">
-        <input class="switch toggle-display" type="checkbox" id="show_phone_numbers" data-filter=".phone-number">
-        <label for="show_phone_numbers">{% trans "Telefonnummern anzeigen" %}</label>
-    </span>
+    {% if can_see_emails or perms.juntagrico.can_send_mails %}
+        <span class="switch switch-sm">
+            <input class="switch toggle-display" type="checkbox" id="show_emails" data-filter=".email" checked="checked">
+            <label for="show_emails">{% trans "E-Mail-Adressen anzeigen" %}</label>
+        </span>
+    {% endif %}
+    {% if can_see_phone_numbers or perms.juntagrico.view_member or perms.juntagrico.change_member %}
+        <span class="switch switch-sm">
+            <input class="switch toggle-display" type="checkbox" id="show_phone_numbers" data-filter=".phone-number">
+            <label for="show_phone_numbers">{% trans "Telefonnummern anzeigen" %}</label>
+        </span>
+    {% endif %}
     {% if co_members %}
         <span class="switch switch-sm">
             <input class="switch toggle-display" type="checkbox" id="show_co_members" data-filter=".co-member">

--- a/juntagrico/templates/juntagrico/menu/admin/activityareas.html
+++ b/juntagrico/templates/juntagrico/menu/admin/activityareas.html
@@ -2,7 +2,7 @@
 {% load juntagrico.config %}
 {% load i18n %}
 {% area_admin request as qs_area_admin %}
-{% if perms.juntagrico.is_area_admin and qs_area_admin|length > 0 %}
+{% if qs_area_admin|length > 0 %}
     <li class="nav-item">
         <a class="nav-link" data-toggle="collapse" href="#areaman">
             {% trans "Tätigkeitsbereiche" %}

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -3,20 +3,22 @@
 {% load juntagrico.config %}
 {% show_core as b_show_core %}
 {% show_job_extras as b_show_job_extras %}
+
 {% block tools %}
-    {% if perms.juntagrico.change_recuringjob %}
-        <a href="{% url 'admin:juntagrico_recuringjob_add' %}" class="edit">
-            <i class="fas fa-plus"></i>
+    {% if perms.juntagrico.change_recuringjob or can_manage_jobs %}
+        <a href="{% url 'admin:juntagrico_recuringjob_add' %}" class="btn btn-primary mr-1">
+            <i class="fas fa-calendar-plus mr-1"></i>
             {% trans "Wiederkehrenden Einsatz ausschreiben" %}
-        </a><br>
+        </a>
     {% endif %}
-    {% if perms.juntagrico.change_onetimejob %}
-        <a href="{% url 'admin:juntagrico_onetimejob_add' %}" class="edit">
-            <i class="fas fa-plus"></i>
+    {% if perms.juntagrico.change_onetimejob or can_manage_jobs %}
+        <a href="{% url 'admin:juntagrico_onetimejob_add' %}" class="btn btn-outline-primary">
+            <i class="fas fa-plus mr-1"></i>
             {% trans "Einzel-Einsatz ausschreiben" %}
         </a>
     {% endif %}
 {% endblock %}
+
 <table id="filter-table" class="list table" data-search='{"smart": true, "regex": false}'>
     {% include "juntagrico/job/list/snippets/header.html" with hidden_description_column=True %}
     <tbody>

--- a/juntagrico/templatetags/juntagrico/common.py
+++ b/juntagrico/templatetags/juntagrico/common.py
@@ -9,6 +9,7 @@ from juntagrico.dao.depotdao import DepotDao
 from juntagrico.dao.jobextradao import JobExtraDao
 from juntagrico.dao.subscriptionproductdao import SubscriptionProductDao
 from juntagrico.dao.subscriptiontypedao import SubscriptionTypeDao
+from juntagrico.entity.jobs import ActivityArea
 
 register = template.Library()
 
@@ -68,7 +69,8 @@ def depot_admin(request):
 @register.simple_tag
 def area_admin(request):
     if hasattr(request.user, 'member'):
-        return ActivityAreaDao.areas_by_coordinator(request.user.member)
+        return ActivityArea.objects.filter(areacoordinator__member=request.user.member,
+                                           areacoordinator__can_view_member=True)
     return []
 
 

--- a/juntagrico/templatetags/juntagrico/common.py
+++ b/juntagrico/templatetags/juntagrico/common.py
@@ -69,8 +69,10 @@ def depot_admin(request):
 @register.simple_tag
 def area_admin(request):
     if hasattr(request.user, 'member'):
-        return ActivityArea.objects.filter(areacoordinator__member=request.user.member,
-                                           areacoordinator__can_view_member=True)
+        return ActivityArea.objects.filter(
+            coordinator_access__member=request.user.member,
+            coordinator_access__can_view_member=True
+        )
     return []
 
 

--- a/juntagrico/tests/test_adminforms.py
+++ b/juntagrico/tests/test_adminforms.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from django.conf import settings
 
 from juntagrico.admins.forms.delivery_copy_form import DeliveryCopyForm
-from juntagrico.admins.forms.job_copy_form import JobCopyForm, JobCopyToFutureForm
+from juntagrico.admins.forms.job_copy_form import JobMassCopyForm, JobMassCopyToFutureForm
 from juntagrico.admins.forms.location_replace_form import LocationReplaceForm
 from juntagrico.entity.delivery import Delivery
 from juntagrico.entity.jobs import RecuringJob
@@ -48,7 +48,7 @@ class JobFormTests(JuntagricoTestCase):
                 'end_date': '26.07.2020',
                 'weekly': '7'
                 }
-        form = JobCopyForm(instance=self.job1, data=data)
+        form = JobMassCopyForm(instance=self.job1, data=data)
         form.full_clean()
         with self.assertRaises(ValidationError):
             # should raise, because no jobs are created in this date range
@@ -64,7 +64,7 @@ class JobFormTests(JuntagricoTestCase):
                 'end_date': '07.07.2020',
                 'weekly': '7'
                 }
-        form = JobCopyForm(instance=self.complex_job, data=data)
+        form = JobMassCopyForm(instance=self.complex_job, data=data)
         form.full_clean()
         form.clean()
         form.save()
@@ -90,7 +90,7 @@ class JobFormTests(JuntagricoTestCase):
                 'end_date': '15.07.2020',
                 'weekly': '14'
                 }
-        form = JobCopyForm(instance=self.job1, data=data)
+        form = JobMassCopyForm(instance=self.job1, data=data)
         form.full_clean()
         form.save()
         self.assertEqual(RecuringJob.objects.all().count(), initial_count + 2)
@@ -168,7 +168,7 @@ class JobFormTests(JuntagricoTestCase):
                 'end_date': '07.07.2020',
                 'weekly': '7'
                 }
-        form = JobCopyToFutureForm(instance=self.job1, data=data)
+        form = JobMassCopyToFutureForm(instance=self.job1, data=data)
         form.full_clean()
         with self.assertRaises(ValidationError) as validation_error:
             # should raise, because jobs are in the past
@@ -185,7 +185,7 @@ class JobFormTests(JuntagricoTestCase):
                 'end_date': today + datetime.timedelta(7),
                 'weekly': '7'
                 }
-        form = JobCopyToFutureForm(instance=self.job1, data=data)
+        form = JobMassCopyToFutureForm(instance=self.job1, data=data)
         form.full_clean()
         form.clean()
         form.save()

--- a/juntagrico/tests/test_manage_list.py
+++ b/juntagrico/tests/test_manage_list.py
@@ -43,7 +43,7 @@ class ManageListTests(JuntagricoTestCase):
         self.assertGet(reverse('manage-area-member', args=[self.area.pk]), code=404)
         self.assertGet(reverse('manage-area-member', args=[self.area.pk]), member=self.area_admin)
         # member2 has no access
-        self.assertGet(reverse('manage-area-member', args=[self.area.pk]), member=self.member2, code=403)
+        self.assertGet(reverse('manage-area-member', args=[self.area.pk]), member=self.member2, code=404)
 
     def testSubWaitingList(self):
         self.assertGet(reverse('sub-mgmt-waitinglist'))

--- a/juntagrico/urls.py
+++ b/juntagrico/urls.py
@@ -174,6 +174,7 @@ urlpatterns = [
          name='manage-depot-subs'),
     # /manage/area
     path('manage/area/<int:area_id>/member', manage.AreaMemberView.as_view(), name='manage-area-member'),
+    path('manage/area/<int:area_id>/member/<int:member_id>/remove', manage.remove_area_member, name='manage-area-member-remove'),
 
     # /email
     path('my/mails', juntagrico_admin.mails, name='mail'),

--- a/juntagrico/urls.py
+++ b/juntagrico/urls.py
@@ -96,6 +96,7 @@ urlpatterns = [
     path('my/jobs/all', job.all_jobs, name='jobs-all'),
     path('job/list/data', job.list_data, name='jobs-list-data'),
     path('my/jobs/<int:job_id>/', job.job, name='job'),
+    path('job/<int:job_id>/cancel', job.cancel, name='job-cancel'),
 
     # /assignment
     path('assignment/<int:job_id>/<int:member_id>/edit', job.edit_assignment, name='assignment-edit'),

--- a/juntagrico/util/admin.py
+++ b/juntagrico/util/admin.py
@@ -1,9 +1,5 @@
 from django import forms
-from django.contrib import admin
-from django.urls import reverse
 from django.utils.html import format_html
-
-from juntagrico.entity.jobs import OneTimeJob, RecuringJob
 
 
 def formfield_for_coordinator(request, target, field_name, perm, query_function, **kwargs):
@@ -11,14 +7,6 @@ def formfield_for_coordinator(request, target, field_name, perm, query_function,
             not (request.user.is_superuser or request.user.has_perm('juntagrico.is_operations_group'))):
         kwargs['queryset'] = query_function(request.user.member)
     return kwargs
-
-
-def queryset_for_coordinator(model_admin, request, field):
-    qs = super(admin.ModelAdmin, model_admin).get_queryset(request)
-    if request.user.has_perm('juntagrico.is_area_admin') and (
-            not (request.user.is_superuser or request.user.has_perm('juntagrico.is_operations_group'))):
-        return qs.filter(**{field: request.user.member})
-    return qs
 
 
 class MyHTMLWidget(forms.widgets.Widget):
@@ -30,15 +18,3 @@ class MyHTMLWidget(forms.widgets.Widget):
         if value is None:
             return ''
         return format_html(value)
-
-
-def get_job_admin_url(request, job):
-    user = request.user
-    if user.is_superuser or \
-            user.has_perm('juntagrico.is_operations_group') or \
-            job.type.activityarea.coordinator == user.member:
-        if isinstance(job, OneTimeJob) and user.has_perm('juntagrico.change_onetimejob'):
-            return reverse('admin:juntagrico_onetimejob_change', args=(job.id,))
-        if isinstance(job, RecuringJob) and user.has_perm('juntagrico.change_recuringjob'):
-            return reverse('admin:juntagrico_recuringjob_change', args=(job.id,))
-    return ''

--- a/juntagrico/views/__init__.py
+++ b/juntagrico/views/__init__.py
@@ -38,6 +38,7 @@ def home(request):
 
     renderdict = {
         'jobs': sorted(next_jobs.union(pinned_jobs).union(next_promotedjobs), key=lambda sort_job: sort_job.time),
+        'can_manage_jobs': request.user.member.area_access.filter(can_modify_jobs=True).exists(),
         'areas': ActivityAreaDao.all_visible_areas_ordered(),
     }
 
@@ -93,7 +94,7 @@ def show_area(request, area_id):
     '''
     area = get_object_or_404(ActivityArea, id=int(area_id))
     edit_form = None
-    access = area.areacoordinator_set.filter(member=request.user.member).first()
+    access = request.user.member.area_access.filter(area=area).first()
     if access and access.can_modify_area:
         if request.method == 'POST':
             edit_form = AreaDescriptionForm(request.POST, instance=area)
@@ -118,6 +119,7 @@ def show_area(request, area_id):
         'area_checked': area_checked,
         'edit_form': edit_form,
         'can_view_member': access and access.can_view_member,
+        'can_manage_jobs': access and access.can_modify_jobs
     }
     return render(request, 'area.html', renderdict)
 

--- a/juntagrico/views/job.py
+++ b/juntagrico/views/job.py
@@ -27,6 +27,7 @@ def jobs(request):
     renderdict = {
         'jobs': jobs,
         'show_all': True,
+        'can_manage_jobs': request.user.member.area_access.filter(can_modify_jobs=True).exists(),
     }
     return render(request, 'jobs.html', renderdict)
 
@@ -101,12 +102,16 @@ def all_jobs(request):
     All jobs to be sorted etc.
     '''
     jobs = JobDao.jobs_ordered_by_time()
+    context = {
+        'can_manage_jobs': request.user.member.area_access.filter(can_modify_jobs=True).exists(),
+    }
     if jobs.count() > 1000:
         # use server side processing when data set is too large
         return render(request, 'juntagrico/job/list/all.html', {
             'jobs': Job.objects.none()
+            **context
         })
-    return render(request, 'jobs.html', {'jobs': jobs})
+    return render(request, 'jobs.html', {'jobs': jobs, **context})
 
 
 @login_required

--- a/juntagrico/views/manage.py
+++ b/juntagrico/views/manage.py
@@ -86,7 +86,6 @@ class MemberActiveView(MemberView):
 
 
 class AreaMemberView(MemberView):
-    permission_required = 'juntagrico.is_area_admin'
     title = _('Alle aktiven {member} im Tätigkeitsbereich {area_name}').format(
         member=Config.vocabulary('member_pl'), area_name='{area_name}'
     )
@@ -95,7 +94,8 @@ class AreaMemberView(MemberView):
         self.area = get_object_or_404(
             ActivityArea,
             id=int(self.kwargs['area_id']),
-            coordinator=self.request.user.member
+            areacoordinator__member=self.request.user.member,
+            areacoordinator__can_view_member=True
         )
         return self.area.members.active().prefetch_for_list
 

--- a/juntagrico/views/manage.py
+++ b/juntagrico/views/manage.py
@@ -96,8 +96,8 @@ class AreaMemberView(MemberView):
         self.area = get_object_or_404(
             ActivityArea,
             id=int(self.kwargs['area_id']),
-            areacoordinator__member=self.request.user.member,
-            areacoordinator__can_view_member=True
+            coordinator_access__member=self.request.user.member,
+            coordinator_access__can_view_member=True
         )
         return self.area.members.active().prefetch_for_list
 
@@ -118,8 +118,8 @@ def remove_area_member(request, area_id, member_id):
     area = get_object_or_404(
         ActivityArea,
         id=area_id,
-        areacoordinator__member=request.user.member,
-        areacoordinator__can_remove_member=True
+        coordinator_access__member=request.user.member,
+        coordinator_access__can_remove_member=True
     )
     area.members.remove(member_id)
     return return_to_previous_location(request)

--- a/testsettings.py
+++ b/testsettings.py
@@ -34,7 +34,7 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.admin',
+    'juntagrico.admin_sites.JuntagricoAdminConfig',
     'fontawesomefree',
     'impersonate',
     # 'juntagrico_test_addon',  # enable only to test addon features

--- a/testsettings.py
+++ b/testsettings.py
@@ -49,7 +49,7 @@ INSTALLED_APPS = [
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'dev.1.7.db',
+        'NAME': 'dev.340.db',
     }
 }
 


### PR DESCRIPTION
# Description
- Enable multiple area coordinators: implements #340
- Replace `is_area_admin` permission by per area and coordinator options.
- Move more coordinator tools to front page: Editing area description, removing members from area
- Removed subscription details from area member list. Coordinator does not need to see that.
- Added single job copy form.
- Added buttons on top of job for easier editing and copying
- Fix: Only show visible locations in autocomplete field

# TODO
- [ ] Display (selected) coordinators in area page
- [ ] Implement per area assignment management permission
- [ ] Show job contacts to job coordinator.
    - [ ] Allow editing them?
- [ ] Let job coordinator use job extras
- [ ] Show email and phone number in separate column in area member list
- [ ] Optionally display members subscription to coordinator? (backwards compatibility)
- [ ] write migrations, remove area.coordinator field and `is_area_admin` permission
- [ ] write tests

# Release Notes
- In your INSTALLED_APPS replace `django.contrib.admin` with `juntagrico.admin_sites.JuntagricoAdminConfig`
