### PR TITLE
fix: primary member can not leave active subscription

### DIFF
--- a/juntagrico/forms.py
+++ b/juntagrico/forms.py
@@ -103,9 +103,11 @@ class AbstractMemberCancellationForm(ModelForm):
 
     def save(self, commit=True):
         if (sub := self.instance.subscription_current) is not None:
-            self.instance.leave_subscription(sub)
+            if sub.primary_member != self.instance:
+                self.instance.leave_subscription(sub)
         if (sub := self.instance.subscription_future) is not None:
-            self.instance.leave_subscription(sub)
+            if sub.primary_member != self.instance:
+                self.instance.leave_subscription(sub)
         self.instance.cancel()
         return super().save(commit)
 


### PR DESCRIPTION
# Description
Member could cancel their subscription and then move on to cancel their membership. In that process they would leave the subscription, leaving it in an inconsistent state, i.e., active without any joined member.
This fix prevents them from leaving if they are the primary member.

# TODO
- [ ] Member should not leave subscription in any case, when canceling membership, but only when membership is deactivated. Implement a proper solution with. #554
