### PR TITLE
fix: give area and depot admins access to send individual emails

### DIFF
--- a/juntagrico/views/email.py
+++ b/juntagrico/views/email.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.decorators import permission_required
 from django.shortcuts import get_object_or_404, render
 from django.utils.translation import get_language
 
@@ -6,9 +5,12 @@ from juntagrico.util.settings import tinymce_lang
 
 from juntagrico.entity.mailing import MailTemplate
 from juntagrico.entity.member import Member
+from juntagrico.view_decorators import any_permission_required
 
 
-@permission_required('juntagrico.can_send_mails')
+@any_permission_required('juntagrico.can_send_mails',
+                         'juntagrico.is_depot_admin',
+                         'juntagrico.is_area_admin')
 def to_member(request, member_id, mail_url='mail-send'):
     renderdict = {
         'recipients': get_object_or_404(Member, id=member_id).email,


### PR DESCRIPTION
So far they had access to send emails to all selected members in the list, but not to individuals, by clicking on their email
