### PR TITLE
dev: Upgrade dependencies

### DIFF
--- a/.github/workflows/juntagrico-ci.yml
+++ b/.github/workflows/juntagrico-ci.yml
@@ -21,11 +21,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: '3.9'
           - python-version: '3.10'
           - python-version: '3.11'
           - python-version: '3.11'
             exclude-test: shares
+          - python-version: '3.12'
+          - python-version: '3.13'
 
     services:
       postgres:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python3 -m pip install build --user

--- a/juntagrico/entity/__init__.py
+++ b/juntagrico/entity/__init__.py
@@ -159,5 +159,5 @@ def absolute_url(*args, **kwargs):
 
 
 def validate_iban(value):
-    if value != '' and not IBAN(value, True).is_valid:
+    if value != '' and not IBAN(value, allow_invalid=True).is_valid:
         raise ValidationError(_('IBAN ist nicht gültig'))

--- a/juntagrico/forms.py
+++ b/juntagrico/forms.py
@@ -430,7 +430,7 @@ class SubscriptionTypeOption(Div):
         self.value = instance.id
         self.name = name
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
         template = self.get_template_name(template_pack)
         return render_to_string(template, {"type": self.instance, "option": self})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,35 +10,37 @@ authors = [
 ]
 readme = "README.md"
 license = { file = "LICENSE.txt" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-    "Django~=4.2.22",
-    "django-admin-sortable2~=2.1.10",
-    "django-crispy-forms~=1.14.0",
-    "django-impersonate~=1.9.1",
-    "django-polymorphic~=3.1.0",
+    "Django~=5.2.3",
+    "django-admin-sortable2~=2.2.8",
+    "django-crispy-forms~=2.4.0",
+    "crispy-bootstrap4~=2025.6.0",
+    "django-impersonate~=1.9.5",
+    "django-polymorphic~=4.1.0",
     "django-richtextfield~=1.6.1",
-    "django-import-export~=4.2.0",
-    "icalendar~=5.0.0",
-    "schwifty==2023.6.0",
-    "xhtml2pdf==0.2.16",
-    "XlsxWriter==3.1.4",
-    "python-dateutil~=2.8.2",
-    "fontawesomefree~=6.4.2",
+    "django-import-export~=4.3.6",
+    "icalendar~=6.3.0",
+    "schwifty==2025.06.0",
+    "xhtml2pdf==0.2.17",
+    "XlsxWriter~=3.2.3",
+    "python-dateutil~=2.9.0",
+    "fontawesomefree~=6.6.0",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "Intended Audience :: Other Audience",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP :: Site Management",
 ]
 dynamic = ["version"]

--- a/settings/minimal.py
+++ b/settings/minimal.py
@@ -20,6 +20,7 @@ INSTALLED_APPS = [
     'impersonate',
     'juntagrico',
     'crispy_forms',
+    'crispy_bootstrap4',
     'adminsortable2',
     'polymorphic',
     'import_export',


### PR DESCRIPTION
# Description
- Upgrade to django 5.2
- Upgrade python dependencies
- Added support for python 3.12 and 3.13. Dropped support for python 3.9.

# TODO
- [ ] upgrade js dependencies
- [ ] upgrade to bootstrap 5

# Release Notes

## Upgrade instructions
- Dropped support for python 3.9.
- Add `crispy_bootstrap4` to the `INSTALLED_APPS`, right after `crispy_forms`
