### PR TITLE
Update iso20022 payment file export for shares

### DIFF
--- a/juntagrico/templates/iso20022/share_pain.001.xml
+++ b/juntagrico/templates/iso20022/share_pain.001.xml
@@ -1,17 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 {% load i18n %}
 {% load juntagrico.config %}
 {% load juntagrico.share %}
 {% vocabulary "share" as v_share %}
 <Document
-        xsi:schemaLocation="http://www.six-interbank-clearing.com/de/pain.001.001.09.ch.03.xsd pain.001.001.09.ch.03.xsd"
+        xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:pain.001.001.09 pain.001.001.09.ch.03.xsd"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="http://www.six-interbank-clearing.com/de/pain.001.001.09.ch.03.xsd">
+        xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.09">
     <CstmrCdtTrfInitn>
         <GrpHdr>
             <MsgId>MsgId-001</MsgId>
             <CreDtTm>{{ now|date:"Y-m-d" }}T{{ now|date:"H:i:s" }}</CreDtTm>
             <NbOfTxs>{{ nmbr_of_tx }}</NbOfTxs>
-            <CtrlSum>{{ total_amount }}</CtrlSum>
+            <CtrlSum>{{ total_amount | floatformat:"2u" }}</CtrlSum>
             <InitgPty>
                 <Nm>{{ name }}</Nm>
                 <CtctDtls>
@@ -30,15 +31,15 @@
             <PmtInfId>PmtInfId-001-01</PmtInfId>
             <PmtMtd>TRF</PmtMtd>
             <BtchBookg>true</BtchBookg>
-            <ReqdExctn>
+            <ReqdExctnDt>
                 <Dt>{{ now|date:"Y-m-d" }}</Dt>
-            </ReqdExctn>
+            </ReqdExctnDt>
             <Dbtr>
                 <Nm>{{ name }}</Nm>
             </Dbtr>
             <DbtrAcct>
                 <Id>
-                    <IBAN>{{ banking_info.IBAN|clean_iban }}</IBAN>
+                    <IBAN>{{ banking_info.IBAN | clean_iban }}</IBAN>
                 </Id>
                 <Tp>
                     <Prtry>CND</Prtry>
@@ -56,7 +57,7 @@
                     <EndToEndId>EndToEndId-001-01-{{ share.id }}</EndToEndId>
                 </PmtId>
                 <Amt>
-                    <InstdAmt Ccy="CHF">{{ share.value }}</InstdAmt>
+                    <InstdAmt Ccy="CHF">{{ share.value | floatformat:"2u" }}</InstdAmt>
                 </Amt>
                 <Cdtr>
                     <Nm>{{ share.member.first_name }} {{ share.member.last_name }}</Nm>

--- a/juntagrico/templatetags/juntagrico/share.py
+++ b/juntagrico/templatetags/juntagrico/share.py
@@ -26,6 +26,6 @@ def required_for_subscription(share, index):
 @register.filter
 def clean_iban(iban_str):
     iban = IBAN(iban_str, allow_invalid=True)
-    if iban.is_valid():
+    if iban.is_valid:
         return str(iban)
     return iban_str


### PR DESCRIPTION
there is a feature to generate an ISO-20022 payment file (pain.001) for paying back shares.
this was introduced in 2019 and uses a now deprecated XML schema.

updated the template to the current pain.001.001.09 schema.

addititional changes:
- format IBAN numbers with a `clean_iban` template filter
- make sure amounts are displayed with a point as decimal separator, regardless of locale settings

upload tested with postfinance (switzerland) online banking.