### PR TITLE
admin: Add option to pin mass copied jobs

### DIFF
--- a/juntagrico/admins/forms/job_copy_form.py
+++ b/juntagrico/admins/forms/job_copy_form.py
@@ -65,6 +65,7 @@ class JobCopyForm(forms.ModelForm):
                 multiplier=inst.multiplier,
                 additional_description=inst.additional_description,
                 duration_override=inst.duration_override,
+                pinned=inst.pinned,
             )
             if commit:
                 newjob.save()

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -51,7 +51,7 @@ class JobAdmin(PolymorphicInlineSupportMixin, OverrideFieldQuerySetMixin, RichTe
     copy_fieldsets = [
         (None, {'fields': [
             'type', ('duration_override', 'type_duration'), 'multiplier', ('slots', 'infinite_slots'),
-            'type_description', 'additional_description'
+            'type_description', 'additional_description', 'pinned'
         ]}),
         (gettext_lazy('Kopieren nach'), {'fields': [
             'new_time', 'start_date', 'end_date', 'weekdays', 'weekly'


### PR DESCRIPTION
Implements #809 

When mass copying job the pinned flag can be set.
It defaults to the value of the copied instance.