### PR TITLE
allow retroactive deactivation of subscription and subscription parts

### DIFF
--- a/juntagrico/entity/__init__.py
+++ b/juntagrico/entity/__init__.py
@@ -118,8 +118,6 @@ class SimpleStateModel(models.Model):
                 raise ValidationError(_('"Aktivierungsdatum" kann nicht nach "Deaktivierungsdatum" liegen'), code='invalid')
             elif not is_canceled:
                 raise ValidationError(_('Bitte "Kündigungsdatum" ausfüllen'), code='missing_cancellation_date')
-            elif self.cancellation_date > self.deactivation_date:
-                raise ValidationError(_('"Kündigungsdatum" kann nicht nach "Deaktivierungsdatum" liegen'), code='invalid')
         if is_canceled and self.cancellation_date > today:
             raise ValidationError(_('Das "Kündigungsdatum" kann nicht in der Zukunft liegen'), code='invalid')
 


### PR DESCRIPTION
implements #808

# Description
The cancellation date has been decoupled from the status of a subscription(part) in an earlier change. The validation that the deactivation date must be after the cancellation date is a leftover that does no longer need to be enforced.
