### PR TITLE
#607 add setting to require subscription during signup

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -323,6 +323,20 @@ ENABLE_REGISTRATION
 
     True
 
+
+REQUIRE_SUBSCRIPTION
+^^^^^^^^^^^^^^^^^^^^
+  Requires selection of a subscription during signup. The option to sign up without subscription is removed.
+
+  Type: Boolean
+
+  default value
+
+  .. code-block:: python
+
+    False
+
+
 ENABLE_EXTERNAL_SIGNUP
 ^^^^^^^^^^^^^^^^^^^
   Activates the external signup API and exposes internal depot and subscription info as json.

--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -92,6 +92,7 @@ class Config:
     enable_shares = _get_setting('ENABLE_SHARES', True)
     required_shares = _get_setting('REQUIRED_SHARES', 1)
     enable_registration = _get_setting('ENABLE_REGISTRATION', True)
+    require_subscription = _get_setting('REQUIRE_SUBSCRIPTION', False)
     signup_manager = _get_setting('SIGNUP_MANAGER', 'juntagrico.util.sessions.SignupManager')
     enable_external_signup = _get_setting('ENABLE_EXTERNAL_SIGNUP', False)
     enforce_mail_confirmation = _get_setting('ENFORCE_MAIL_CONFIRMATION', True)

--- a/juntagrico/views/create_subscription.py
+++ b/juntagrico/views/create_subscription.py
@@ -17,7 +17,8 @@ from juntagrico.dao.depotdao import DepotDao
 from juntagrico.dao.memberdao import MemberDao
 from juntagrico.entity.subtypes import SubscriptionType
 from juntagrico.forms import SubscriptionPartSelectForm, StartDateForm, EditCoMemberForm, RegisterMultiCoMemberForm, \
-    RegisterFirstMultiCoMemberForm, ShareOrderForm, RegisterSummaryForm, SubscriptionExtraPartSelectForm
+    RegisterFirstMultiCoMemberForm, ShareOrderForm, RegisterSummaryForm, SubscriptionExtraPartSelectForm, \
+    SubscriptionPartSelectRequiredForm
 from juntagrico.util import temporal
 from juntagrico.view_decorators import signup_session
 from juntagrico.views_subscription import SignupView
@@ -28,8 +29,11 @@ def select_parts(
         request, signup_manager,
         key='subscriptions',
         form_class=SubscriptionPartSelectForm,
+        required_subscription_form_class=SubscriptionPartSelectRequiredForm,
         template_name='juntagrico/subscription/create/select_subscription.html'
-    ):
+):
+    if Config.require_subscription():
+        form_class = required_subscription_form_class
     subscriptions = signup_manager.get(key, {})
     if request.method == 'POST':
         form = form_class(subscriptions, request.POST)
@@ -51,6 +55,7 @@ def select_extras(request):
         request,
         key='extras',
         form_class=SubscriptionExtraPartSelectForm,
+        required_subscription_form_class=SubscriptionExtraPartSelectForm,
         template_name='juntagrico/subscription/create/select_extras.html'
     )
 


### PR DESCRIPTION
implements #607 

# Description
Added setting `REQUIRE_SUBSCRIPTION`. If set to True, new members can only sign up with a subscription. The option to signup without subscription is removed.
