### PR TITLE
fix: add member to auto-add areas when joining first subscription

### DIFF
--- a/juntagrico/apps.py
+++ b/juntagrico/apps.py
@@ -8,8 +8,10 @@ class JuntagricoAppconfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
 
     def ready(self):
+        from django.db import models
         from . import signals
-        from .models import Subscription, Job, Share, Member
+        from .models import Subscription, Job, Share, Member, SubscriptionMembership
+        from .lifecycle.submembership import add_subscription_member_to_activity_area
 
         signals.depot_changed.connect(signals.on_depot_changed, sender=Subscription)
         signals.depot_change_confirmed.connect(signals.on_depot_change_confirmed, sender=Subscription)
@@ -17,6 +19,7 @@ class JuntagricoAppconfig(AppConfig):
         signals.subscribed.connect(signals.on_job_subscribed, sender=Job)
         signals.assignment_changed.connect(signals.on_assignment_changed, sender=Member)
         signals.share_canceled.connect(signals.on_share_canceled, sender=Share)
+        models.signals.post_save.connect(add_subscription_member_to_activity_area, sender=SubscriptionMembership)
         # See models.py for older signal connections
 
         '''monkey patch User email method for password reset'''

--- a/juntagrico/lifecycle/submembership.py
+++ b/juntagrico/lifecycle/submembership.py
@@ -81,7 +81,7 @@ def check_sub_membership_consistency_ms(sub_membership):
 
 def add_subscription_member_to_activity_area(sender, instance, **kwargs):
     # if member is joining their first subscription, add them to auto-add areas
-    joined = (kwargs['created'] or instance._old['join_date'] is None) and instance.join_date is not None
+    joined = (kwargs['created'] or instance._old['_old']['join_date'] is None) and instance.join_date is not None
     if joined and not instance.member.subscriptionmembership_set.exclude(pk=instance.pk).filter(join_date__isnull=False).exists():
         from juntagrico.dao.activityareadao import ActivityAreaDao
         [area.members.add(instance.member) for area in ActivityAreaDao.all_auto_add_members_areas()]

--- a/juntagrico/lifecycle/submembership.py
+++ b/juntagrico/lifecycle/submembership.py
@@ -77,3 +77,11 @@ def check_sub_membership_consistency_ms(sub_membership):
             ),
             code='invalid'
         )
+
+
+def add_subscription_member_to_activity_area(sender, instance, **kwargs):
+    # if member is joining their first subscription, add them to auto-add areas
+    joined = (kwargs['created'] or instance._old['join_date'] is None) and instance.join_date is not None
+    if joined and not instance.member.subscriptionmembership_set.exclude(pk=instance.pk).filter(join_date__isnull=False).exists():
+        from juntagrico.dao.activityareadao import ActivityAreaDao
+        [area.members.add(instance.member) for area in ActivityAreaDao.all_auto_add_members_areas()]

--- a/juntagrico/tests/test_areas.py
+++ b/juntagrico/tests/test_areas.py
@@ -13,13 +13,13 @@ class AreaTests(JuntagricoTestCase):
         self.assertGet(reverse('area', args=[self.area.pk]))
 
     def testAreaJoinAndLeave(self):
-        self.assertGet(reverse('area-join', args=[self.area.pk]))
-        self.assertEqual(self.area.members.count(), 1)
+        self.assertGet(reverse('area-join', args=[self.area2.pk]))
+        self.assertEqual(self.area2.members.count(), 1)
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].recipients(), ['email_contact@example.org'])
+        self.assertEqual(mail.outbox[0].recipients(), ['email2@email.org', 'areaadmin@email.org'])
         mail.outbox = []
 
-        self.assertGet(reverse('area-leave', args=[self.area.pk]))
-        self.assertEqual(self.area.members.count(), 0)
+        self.assertGet(reverse('area-leave', args=[self.area2.pk]))
+        self.assertEqual(self.area2.members.count(), 0)
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].recipients(), ['email_contact@example.org'])
+        self.assertEqual(mail.outbox[0].recipients(), ['email2@email.org', 'areaadmin@email.org'])

--- a/juntagrico/tests/test_manage_subs.py
+++ b/juntagrico/tests/test_manage_subs.py
@@ -18,11 +18,14 @@ class ManageSubPendingListTests(JuntagricoTestCase):
         self.assertPost(reverse('parts-apply'), member=self.member2, code=302)
         self.assertFalse(self.sub2.parts.first().active)
         # test activation
+        self.assertFalse(self.area.members.filter(pk__in=self.sub2.current_members).exists())
         part = self.sub2.parts.first()
         self.assertPost(reverse('parts-apply'), {'parts[]': [part.id]}, code=302)
         # check that part is active
         part.refresh_from_db()
         self.assertTrue(part.active)
+        # check that members of sub2 where added to area
+        self.assertQuerySetEqual(self.area.members.filter(pk__in=self.sub2.current_members), self.sub2.current_members)
 
     def testSubscriptionDeactivate(self):
         self.assertGet(reverse('parts-apply'), code=302)

--- a/juntagrico/tests/test_subs.py
+++ b/juntagrico/tests/test_subs.py
@@ -130,8 +130,19 @@ class SubscriptionTests(JuntagricoTestCaseWithShares):
 
     def testJoin(self):
         self.assertGet(reverse('add-member', args=[self.sub.pk]), member=self.member)
-        self.assertPost(reverse('add-member', args=[self.sub.pk]), member=self.member,
-                        data={'email': self.member4.email})
+        self.assertPost(
+            reverse('add-member', args=[self.sub.pk]),
+            member=self.member, code=302,
+            data={
+                'email': self.member4.email,
+                # fields are required even with existing email
+                'first_name': '-', 'last_name': '-', 'phone': '-',
+                'addr_street': '-', 'addr_zipcode': '-', 'addr_location': '-',
+            }
+        )
+        self.sub.refresh_from_db()
+        self.assertTrue(self.member4 in self.sub.current_members.all())
+        self.assertTrue(self.member4 in self.area.members.all())
 
     def testJoinLeaveRejoin(self):
         # leaving on the same day should delete the subscription membership again

--- a/juntagrico/views_create_subscription.py
+++ b/juntagrico/views_create_subscription.py
@@ -205,7 +205,8 @@ class CSSummaryView(FormView):
 
     def get_context_data(self, **kwargs):
         args = self.cs_session.to_dict()
-        args['activity_areas'] = ActivityAreaDao.all_auto_add_members_areas()
+        if args['subscriptions']:
+            args['activity_areas'] = ActivityAreaDao.all_auto_add_members_areas()
         return super().get_context_data(
             **{},
             **args,

--- a/juntagrico/views_subscription.py
+++ b/juntagrico/views_subscription.py
@@ -344,14 +344,9 @@ def activate_subscription(request, subscription_id):
     change_date = request.session.get('changedate', None)
     try:
         subscription.activate(change_date)
-        add_subscription_member_to_activity_area(subscription)
     except ValidationError as e:
         return error_page(request, e.message)
     return return_to_previous_location(request)
-
-
-def add_subscription_member_to_activity_area(subscription):
-    [area.members.add(*subscription.current_members) for area in ActivityAreaDao.all_auto_add_members_areas()]
 
 
 @permission_required('juntagrico.is_operations_group')

--- a/juntagrico/views_subscription.py
+++ b/juntagrico/views_subscription.py
@@ -15,7 +15,6 @@ from django.views.generic import FormView
 from django.views.generic.edit import ModelFormMixin
 
 from juntagrico.config import Config
-from juntagrico.dao.activityareadao import ActivityAreaDao
 from juntagrico.dao.depotdao import DepotDao
 from juntagrico.dao.memberdao import MemberDao
 from juntagrico.dao.subscriptionproductdao import SubscriptionProductDao


### PR DESCRIPTION
The function to add new members to selected areas automatically only worked when activating the subscription though the old management list.

This fix adds the member to the area in all cases:
- when subscription is activated through new management list or via django admin
- when members are joining active subscriptions

Areas will only be added for the first subscription of the member. This avoids that existing members who switch to another subscription get added to the areas again.

Also fixes #845 by not showing info about automatic activity areas to new members without subscription during registration as they are not affected.