### PR TITLE
fix: External signup API show all depots

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -338,7 +338,10 @@ REQUIRE_SUBSCRIPTION
 
 
 ENABLE_EXTERNAL_SIGNUP
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
+  .. warning::
+    Enabling external signups with publicly expose some information about your **invisible** depots: name, description, weekday and location.
+
   Activates the external signup API and exposes internal depot and subscription info as json.
 
   Usage: curl -k -L -b -X POST -H 'Content-Type: application/x-www-form-urlencoded' -d 'first_name=John&family_name=Doe&street=Bahnhofstrasse&house_number=42&postal_code=8001&city=Z%C3%BCrich&phone=078%2012345678&email=john.doe@invalid.com&comment=Ich%20freue%20mich%20auf%20den%20Start!&by_laws_accepted=TRUE&subscription_1=1&subscription_2=2&depot_id=1&start_date=2025-12-01&shares=4' 'http://example.com/signup/external'

--- a/juntagrico/views/create_subscription.py
+++ b/juntagrico/views/create_subscription.py
@@ -15,6 +15,7 @@ from juntagrico.dao.activityareadao import ActivityAreaDao
 from juntagrico.dao.depotdao import DepotDao
 from juntagrico.dao.memberdao import MemberDao
 from juntagrico.entity.subtypes import SubscriptionType
+from juntagrico.entity.depot import Depot
 from juntagrico.forms import SubscriptionPartSelectForm, StartDateForm, EditCoMemberForm, RegisterMultiCoMemberForm, \
     ShareOrderForm, RegisterSummaryForm, SubscriptionExtraPartSelectForm, SubscriptionPartSelectRequiredForm
 from juntagrico.util import temporal
@@ -129,7 +130,7 @@ def create_external(request):
     if not Config.enable_external_signup():
         raise Http404
     if request.method == "GET":
-        depots = list(DepotDao.all_visible_depots().values('id', 'name'))
+        depots = list(Depot.objects.all().values('id', 'name', 'visible'))
         subs = list(
             SubscriptionType.objects.visible()
             .values('id', 'name', 'shares', 'required_assignments', 'required_core_assignments',

--- a/juntagrico/views/create_subscription.py
+++ b/juntagrico/views/create_subscription.py
@@ -130,7 +130,17 @@ def create_external(request):
     if not Config.enable_external_signup():
         raise Http404
     if request.method == "GET":
-        depots = list(Depot.objects.all().values('id', 'name', 'visible'))
+        depots = Depot.objects.all().select_related('location')
+        depot_list = []
+        for depot in depots:
+            depot_list.append({
+                'id': depot.id,
+                'name': depot.name,
+                'visible': depot.visible,
+                'weekday': depot.weekday,
+                'description': depot.description,
+                'location': depot.location.map_info,
+            })
         subs = list(
             SubscriptionType.objects.visible()
             .values('id', 'name', 'shares', 'required_assignments', 'required_core_assignments',
@@ -139,7 +149,7 @@ def create_external(request):
         for sub in subs:
             sub['trial'] = sub['trial_days'] > 0
         external_details = {
-            'depots': depots,
+            'depots': depot_list,
             'subscriptions': subs,
         }
         return JsonResponse(external_details, safe=False)


### PR DESCRIPTION
# Description
For the main website, they want all depots exposed with flag "visible" true or false