### PR TITLE
admin: let area admins add participants to jobs #868

### DIFF
--- a/juntagrico/entity/jobs.py
+++ b/juntagrico/entity/jobs.py
@@ -272,7 +272,7 @@ class Job(JuntagricoBasePoly):
         if self.infinite_slots:
             return -1
         if self.slots is not None:
-            return self.slots - self.occupied_slots
+            return max(0, self.slots - self.occupied_slots)
         return 0
 
     @admin.display(description=_('Plätze'), ordering='slots')
@@ -290,6 +290,14 @@ class Job(JuntagricoBasePoly):
     @property
     def occupied_slots(self):
         return self.assignment_set.count()
+
+    def get_multiplier(self):
+        unit = Config.assignment_unit()
+        if unit == 'ENTITY':
+            return self.multiplier
+        elif unit == 'HOURS':
+            return self.multiplier * self.duration
+        return 1
 
     @property
     def duration(self):
@@ -437,6 +445,9 @@ class CheckJobCapabilities:
 
     def can_modify_assignments(self):
         return self.user.has_perm('juntagrico.change_assignment') or self.is_assignment_coordinator
+
+    def can_add_assignments(self):
+        return self.user.has_perm('juntagrico.add_assignment') or self.is_assignment_coordinator
 
     def can_contact_member(self):
         return self.user.has_perm('juntagrico.can_send_mails') or self.access and self.access.can_contact_member

--- a/juntagrico/fixtures/test/members.json
+++ b/juntagrico/fixtures/test/members.json
@@ -10,6 +10,11 @@
         "groups": [],
         "user_permissions": [
             [
+                "add_assignment",
+                "juntagrico",
+                "assignment"
+            ],
+            [
                 "change_assignment",
                 "juntagrico",
                 "assignment"

--- a/juntagrico/forms/__init__.py
+++ b/juntagrico/forms/__init__.py
@@ -17,6 +17,7 @@ from django.utils.html import escape, format_html_join, format_html, strip_tags
 from django.utils.safestring import mark_safe
 from django.utils.text import format_lazy
 from django.utils.translation import gettext as _, gettext_lazy, ngettext_lazy
+from django_select2.forms import ModelSelect2MultipleWidget, ModelSelect2Widget
 from djrichtextfield.widgets import RichTextWidget
 
 from juntagrico.config import Config
@@ -945,3 +946,17 @@ class BusinessYearForm(Form):
 
     def date_range(self):
         return get_business_date_range(int(self.cleaned_data.get('year')))
+
+
+class InternalModelSelect2Mixin:
+    def __init__(self, *args, **kwargs):
+        kwargs['data_view'] = 'internal-select2-view'
+        super().__init__(*args, **kwargs)
+
+
+class InternalModelSelect2Widget(InternalModelSelect2Mixin, ModelSelect2Widget):
+    pass
+
+
+class InternalModelSelect2MultipleWidget(InternalModelSelect2Mixin, ModelSelect2MultipleWidget):
+    pass

--- a/juntagrico/forms/account.py
+++ b/juntagrico/forms/account.py
@@ -2,7 +2,8 @@ import datetime
 
 from crispy_forms.helper import FormHelper
 from django.core.exceptions import ValidationError
-from django.db.models import F
+from django.db.models import F, Exists, OuterRef
+from django.utils.formats import date_format
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _, gettext, ngettext
 
@@ -12,7 +13,11 @@ from juntagrico import signals
 from juntagrico.config import Config
 from juntagrico.entity.member import Member
 from juntagrico.entity.share import Share
-from juntagrico.forms import JuntagricoDateWidget
+from juntagrico.forms import (
+    JuntagricoDateWidget,
+    InternalModelSelect2MultipleWidget,
+    InternalModelSelect2Widget,
+)
 from juntagrico.forms.subscription import CancellationField
 from juntagrico.mailer import adminnotification, membernotification
 from juntagrico.signals import share_canceled
@@ -307,3 +312,37 @@ class CancellationForm(forms.ModelForm):
             summary['account'] = True
 
         return summary
+
+
+class MemberSelect2Mixin:
+    model = Member
+    search_fields = [
+        'first_name__icontains',
+        'last_name__icontains',
+        'email__icontains',
+    ]
+
+    def get_queryset(self):
+        # annotate if another member with the exact same name exists
+        return super().get_queryset().annotate(
+            duplicate=Exists(
+                Member.objects.exclude(pk=OuterRef('pk')).filter(
+                    first_name=OuterRef('first_name'),
+                    last_name=OuterRef('last_name')
+                )
+            )
+        )
+
+    def label_from_instance(self, obj):
+        label = super().label_from_instance(obj)
+        if getattr(obj, 'duplicate', False):
+            label += f' ({date_format(obj.user.date_joined, "SHORT_DATE_FORMAT")})'
+        return label
+
+
+class MemberSelect2Widget(MemberSelect2Mixin, InternalModelSelect2Widget):
+    pass
+
+
+class MemberSelect2MultipleWidget(MemberSelect2Mixin, InternalModelSelect2MultipleWidget):
+    pass

--- a/juntagrico/forms/email.py
+++ b/juntagrico/forms/email.py
@@ -5,14 +5,11 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Submit, Field, Fieldset, HTML
 from django import forms
 from django.core.mail import EmailMultiAlternatives
-from django.db.models import OuterRef, Exists
 from django.forms import Media
 from django.template.loader import get_template
 from django.urls import reverse
-from django.utils.formats import date_format
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from django_select2.forms import ModelSelect2MultipleWidget
 from djrichtextfield.widgets import RichTextWidget
 
 from juntagrico.config import Config
@@ -20,6 +17,8 @@ from juntagrico.entity.depot import Depot
 from juntagrico.entity.jobs import ActivityArea, Job
 from juntagrico.entity.mailing import MailTemplate
 from juntagrico.entity.member import Member
+from juntagrico.forms import InternalModelSelect2MultipleWidget
+from juntagrico.forms.account import MemberSelect2MultipleWidget
 from juntagrico.util.html import EmailHtmlParser
 
 
@@ -41,41 +40,9 @@ class MultipleFileInput(forms.FileInput):
         return super().media + Media(js=['juntagrico/js/forms/attachmentAppender.js'])
 
 
-class InternalModelSelect2MultipleWidget(ModelSelect2MultipleWidget):
-    def __init__(self, *args, **kwargs):
-        kwargs['data_view'] = 'internal-select2-view'
-        super().__init__(*args, **kwargs)
-
-
 class JobSelect2MultipleWidget(InternalModelSelect2MultipleWidget):
     def label_from_instance(self, obj):
         return obj.get_label()
-
-
-class MemberSelect2MultipleWidget(InternalModelSelect2MultipleWidget):
-    model = Member
-    search_fields = [
-        'first_name__icontains',
-        'last_name__icontains',
-        'email__icontains',
-    ]
-
-    def get_queryset(self):
-        # annotate if another member with the exact same name exists
-        return super().get_queryset().annotate(
-            duplicate=Exists(
-                Member.objects.exclude(pk=OuterRef('pk')).filter(
-                    first_name=OuterRef('first_name'),
-                    last_name=OuterRef('last_name')
-                )
-            )
-        )
-
-    def label_from_instance(self, obj):
-        label = super().label_from_instance(obj)
-        if getattr(obj, 'duplicate', False):
-            label += f' ({date_format(obj.user.date_joined, "SHORT_DATE_FORMAT")})'
-        return label
 
 
 class BaseRecipientsForm(forms.Form):

--- a/juntagrico/forms/job.py
+++ b/juntagrico/forms/job.py
@@ -3,34 +3,66 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit, Layout, Field, Div, HTML
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.forms import Form, ChoiceField, CharField, Textarea, BooleanField, ModelChoiceField
+from django.forms import (
+    Form,
+    TypedChoiceField,
+    CharField,
+    Textarea,
+    BooleanField,
+    ModelChoiceField,
+)
 from django.template.loader import get_template
 from django.utils import timezone
 from django.utils.translation import gettext as _, gettext_lazy
 from django_select2.forms import ModelSelect2Widget
 
+from juntagrico import forms
 from juntagrico.config import Config
 from juntagrico.entity.jobs import JobExtra, Assignment, Job, JobType
 from juntagrico.entity.member import Member
 from juntagrico.signals import subscribed, assignment_changed
 
 
-class JobSubscribeForm(Form):
+class SlotField(TypedChoiceField):
     MAX_VALUE = 15
+
+    labels = dict(
+        option_0=gettext_lazy('Abmelden'),
+        option_1=gettext_lazy('Alleine'),
+        option_2=gettext_lazy('Zu Zweit'),
+        option_3=gettext_lazy('Zu Dritt'),
+        option_4=gettext_lazy('Zu Viert'),
+        option_x=lambda x: _('{0} Personen').format(x),
+    )
+
+    def set_choices(self, min_slots, max_slots=MAX_VALUE, option_labels=None):
+        max_slots = min(max_slots or self.MAX_VALUE, self.MAX_VALUE)
+        choices = []
+        for i in range(min_slots, max_slots + 1):
+            label = self.get_option_text(i, option_labels)
+            choices.append((i, label))
+        self.choices = choices
+
+    def get_option_text(self, index, option_labels=None):
+        option_labels = self.labels | (option_labels or {})
+        return option_labels.get(f'option_{index}') or option_labels['option_x'](index)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.coerce = lambda x: int(x)
+
+
+class JobSubscribeForm(Form):
     UNSUBSCRIBE = 'unsubscribe'
 
-    slots = ChoiceField(label=_('Ich trage mich ein:'))
+    slots = SlotField(label=_('Ich trage mich ein:'))
     message = CharField(label=_('Mitteilung:'), widget=Textarea(attrs={"rows": 3}), required=False,
                         help_text=_('Diese Mitteilung wird an die Einsatz-Koordination gesendet'))
 
     text = {
         'options': {
-            0: _('Abmelden'),
-            1: _('Unbegleitet'),
-            2: _('Zu Zweit'),
-            3: _('Zu Dritt'),
-            4: _('Zu Viert'),
-            None: lambda x: _('{0} weitere Personen und ich').format(x - 1)
+            'option_1': _('Unbegleitet'),
+            'option_x': lambda x: _('{0} weitere Personen und ich').format(x - 1)
         },
     }
     message_wrapper_class = 'd-none'  # let js display the field if needed
@@ -41,7 +73,7 @@ class JobSubscribeForm(Form):
         self.job = job
         self.current_assignments = job.assignment_set.filter(member=member)
         self.current_slots = self.current_assignments.count()
-        self.available_slots = self.MAX_VALUE if self.job.infinite_slots else self.job.free_slots + self.current_slots
+        self.available_slots = None if self.job.infinite_slots else self.job.free_slots + self.current_slots
         # form layout
         self.helper = FormHelper()
         self.helper.form_class = 'form-horizontal'
@@ -63,7 +95,11 @@ class JobSubscribeForm(Form):
             extras.append(field_name)
         for selected_extra in selected_extras:
             self.initial[f'extra{selected_extra.extra_type.id}'] = True
-        self.fields['slots'].choices = self.get_choices
+        self.fields["slots"].set_choices(
+            min_slots=0 if self.can_unsubscribe else max(1, self.current_slots),
+            max_slots=self.available_slots,
+            option_labels=self.text['options']
+        )
         self.initial['slots'] = self.current_slots
 
         # show buttons depending on status
@@ -97,16 +133,6 @@ class JobSubscribeForm(Form):
                 css_class='offset-md-3 col-md-6 mb-3 d-none'
             ))
 
-    def get_option_text(self, index):
-        return self.text['options'].get(index, self.text['options'][None](index))
-
-    def get_choices(self):
-        max_slots = min(self.available_slots, self.MAX_VALUE)
-        min_slots = 0 if self.can_unsubscribe else max(1, self.current_slots)
-        for i in range(min_slots, max_slots + 1):
-            label = self.get_option_text(i)
-            yield i, label
-
     @property
     def can_unsubscribe(self):
         return self.current_slots > 0 and Config.allow_job_unsubscribe()
@@ -128,7 +154,7 @@ class JobSubscribeForm(Form):
         return cleaned_data
 
     def save(self):
-        slots = int(self.cleaned_data['slots'])
+        slots = self.cleaned_data['slots']
 
         # handle unsubscribe action
         if self.cleaned_data[self.UNSUBSCRIBE] or slots == 0:
@@ -142,7 +168,7 @@ class JobSubscribeForm(Form):
                 assignment = Assignment(
                     member=self.member,
                     job=self.job,
-                    amount=self.get_multiplier(),
+                    amount=self.job.get_multiplier(),
                     core_cache=self.job.type.activityarea.core
                 )
                 Assignment.objects.bulk_create([assignment] * slots)
@@ -154,14 +180,6 @@ class JobSubscribeForm(Form):
                         assignment.job_extras.add(extra)
                 assignment.save()
         self.send_signals(slots, self.cleaned_data['message'])
-
-    def get_multiplier(self):
-        unit = Config.assignment_unit()
-        if unit == 'ENTITY':
-            return self.job.multiplier
-        elif unit == 'HOURS':
-            return self.job.multiplier * self.job.duration
-        return 1
 
     def send_signals(self, slots, message=''):
         # send signals
@@ -175,23 +193,20 @@ class EditAssignmentForm(JobSubscribeForm):
     text = dict(
         message_to_member=gettext_lazy('Mitteilung an das Mitglied'),
         slots_label=gettext_lazy('Teilnahme'),
-        option_1=gettext_lazy('Alleine'),
-        option_x=gettext_lazy('{0} Personen'),
         **JobSubscribeForm.text,
     )
 
     def __init__(self, editor, can_delete, *args, **kwargs):
+        self.can_delete = can_delete
         super().__init__(*args, **kwargs)
         self.editor = editor
-        self.can_delete = can_delete
         self.helper.form_id = 'assignment-edit-form'
         self.fields['message'].help_text = self.text['message_to_member']
         self.fields['slots'].label = self.text['slots_label']
-
-    def get_option_text(self, index):
-        if index == 1:
-            return self.text['option_1']
-        return self.text['options'].get(index, self.text['option_x'].format(index))
+        self.fields["slots"].set_choices(
+            min_slots=0 if can_delete else max(1, self.current_slots),
+            max_slots=self.available_slots,
+        )
 
     @property
     def can_unsubscribe(self):
@@ -207,6 +222,27 @@ class EditAssignmentForm(JobSubscribeForm):
             count=slots, initial_count=self.current_slots,
             message=message
         )
+
+
+class AddAssignmentForm(Form):
+    account = ModelChoiceField(None, label=_('Wer?'), widget=forms.account.MemberSelect2Widget)
+    slots = SlotField(label=_('Teilnahme:'))
+
+    def __init__(self, job, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.prefix = 'add'
+        self.job = job
+        self.fields['account'].queryset = Member.objects.active()
+        self.fields['slots'].set_choices(1)
+
+    def save(self):
+        assignment = Assignment(
+            member=self.cleaned_data['account'],
+            job=self.job,
+            amount=self.job.get_multiplier(),
+            core_cache=self.job.type.activityarea.core
+        )
+        Assignment.objects.bulk_create([assignment] * self.cleaned_data['slots'])
 
 
 class ConvertToRecurringJobForm(Form):

--- a/juntagrico/forms/job.py
+++ b/juntagrico/forms/job.py
@@ -16,10 +16,10 @@ from django.utils import timezone
 from django.utils.translation import gettext as _, gettext_lazy
 from django_select2.forms import ModelSelect2Widget
 
-from juntagrico import forms
 from juntagrico.config import Config
 from juntagrico.entity.jobs import JobExtra, Assignment, Job, JobType
 from juntagrico.entity.member import Member
+from juntagrico.forms.account import MemberSelect2Widget
 from juntagrico.signals import subscribed, assignment_changed
 
 
@@ -139,7 +139,7 @@ class JobSubscribeForm(Form):
 
     @property
     def can_interact(self):
-        can_subscribe = self.available_slots > 0
+        can_subscribe = self.available_slots is None or self.available_slots > 0
         return self.job.start_time() > timezone.now() and not self.job.canceled and (can_subscribe or self.can_unsubscribe)
 
     def clean(self):
@@ -225,7 +225,7 @@ class EditAssignmentForm(JobSubscribeForm):
 
 
 class AddAssignmentForm(Form):
-    account = ModelChoiceField(None, label=_('Wer?'), widget=forms.account.MemberSelect2Widget)
+    account = ModelChoiceField(None, label=_('Wer?'), widget=MemberSelect2Widget)
     slots = SlotField(label=_('Teilnahme:'))
 
     def __init__(self, job, *args, **kwargs):

--- a/juntagrico/forms/job.py
+++ b/juntagrico/forms/job.py
@@ -225,24 +225,38 @@ class EditAssignmentForm(JobSubscribeForm):
 
 
 class AddAssignmentForm(Form):
-    account = ModelChoiceField(None, label=_('Wer?'), widget=MemberSelect2Widget)
+    account = ModelChoiceField(
+        None, label=_('Wer?'), widget=MemberSelect2Widget,
+        help_text=_('Wird automatisch informiert.')
+    )
     slots = SlotField(label=_('Teilnahme:'))
 
-    def __init__(self, job, *args, **kwargs):
+    def __init__(self, job, *args, editor=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.prefix = 'add'
         self.job = job
+        self.editor = editor
         self.fields['account'].queryset = Member.objects.active()
         self.fields['slots'].set_choices(1)
 
     def save(self):
+        account = self.cleaned_data['account']
+        slots = self.cleaned_data['slots']
         assignment = Assignment(
-            member=self.cleaned_data['account'],
+            member=account,
             job=self.job,
             amount=self.job.get_multiplier(),
             core_cache=self.job.type.activityarea.core
         )
-        Assignment.objects.bulk_create([assignment] * self.cleaned_data['slots'])
+        Assignment.objects.bulk_create([assignment] * slots)
+        self.send_signals(account, slots)
+
+    def send_signals(self, account, slots):
+        initial_count = self.job.assignment_set.filter(member=account).count() - slots
+        assignment_changed.send(
+            Member, instance=account, job=self.job, editor=self.editor,
+            count=slots, initial_count=initial_count
+        )
 
 
 class ConvertToRecurringJobForm(Form):

--- a/juntagrico/mailer/adminnotification.py
+++ b/juntagrico/mailer/adminnotification.py
@@ -257,6 +257,10 @@ def _template_assignment_changed(job, subject, template_name, **kwargs):
         ).send()
 
 
+def assignment_added(job, **kwargs):
+    _template_assignment_changed(job, _('Einsatzanmeldung'), 'added', **kwargs)
+
+
 def assignment_changed(job, **kwargs):
     _template_assignment_changed(job, _('Änderung der Einsatzanmeldung'), 'changed', **kwargs)
 

--- a/juntagrico/mailer/membernotification.py
+++ b/juntagrico/mailer/membernotification.py
@@ -167,6 +167,16 @@ def job_unsubscribed(participant, job, count):
     ).continue_thread(job).send()
 
 
+def assignment_added(participant, **kwargs):
+    EmailBuilder(
+        participant,
+        _('Für Einsatz angemeldet'),
+        'juntagrico/mails/member/assignment/added.txt',
+        kwargs,
+        reply_to=[kwargs.get('editor').email]
+    ).start_thread(kwargs['job']).send()
+
+
 def assignment_changed(participant, **kwargs):
     EmailBuilder(
         participant,

--- a/juntagrico/management/commands/mailtexts.py
+++ b/juntagrico/management/commands/mailtexts.py
@@ -184,11 +184,17 @@ class Command(BaseCommand):
                     count=1,
                     message='[Nachricht an Mitglied]'
                 )
+                print("*** member/assignment/added ***")
+                membernotification.assignment_added(member, **assignment_context)
+
                 print('*** member/assignment/changed ***')
                 membernotification.assignment_changed(member, **assignment_context)
 
                 print('*** member/assignment/removed ***')
                 membernotification.assignment_removed(member, **assignment_context)
+
+                print("*** admin/assignment/added ***")
+                adminnotification.assignment_added(**assignment_context)
 
                 print('*** admin/assignment/changed ***')
                 adminnotification.assignment_changed(**assignment_context)

--- a/juntagrico/signals.py
+++ b/juntagrico/signals.py
@@ -75,14 +75,19 @@ def on_job_subscribed(sender, **kwargs):
 def on_assignment_changed(sender, **kwargs):
     member = kwargs.get('instance')
     editor = kwargs.get('editor')
+    initial_count = kwargs.get('initial_count')
     count = kwargs.get('count')
     if member != editor:  # don't send this notification if editor changed their own assignment
         if count == 0:
             membernotification.assignment_removed(member, **kwargs)
+        elif initial_count == 0:
+            membernotification.assignment_added(member, **kwargs)
         else:
             membernotification.assignment_changed(member, **kwargs)
     if count == 0:
         adminnotification.assignment_removed(**kwargs)
+    elif initial_count == 0:
+        adminnotification.assignment_added(**kwargs)
     else:
         adminnotification.assignment_changed(**kwargs)
 

--- a/juntagrico/static/juntagrico/js/initJob.js
+++ b/juntagrico/static/juntagrico/js/initJob.js
@@ -79,6 +79,16 @@ $(function () {
         return false
     })
 
+    // open modal to add assignment
+    $('.add-assignment').on('click', function (event) {
+        let modal = $('#add_assignment_modal')
+        modal.modal('show')
+        modal.find('.django-select2').not('[name*=__prefix__]').djangoSelect2({
+            dropdownParent: modal
+        })
+        return false
+    })
+
     // apply suggested job types on click
     $('.suggested-job-type').on('click', function (event) {
         let suggestion = $(this)

--- a/juntagrico/templates/job.html
+++ b/juntagrico/templates/job.html
@@ -272,11 +272,7 @@
                 {% endif %}
             </div>
             <div class="col-lg-9">
-                {% if job.occupied_slots == 0 and job.free_slots != 0 %}
-                    {% trans "Noch niemand" %} 🥺
-                {% else %}
-                    {% job_participant_list request.user job %}
-                {% endif %}
+                {% job_participant_list request.user job %}
             </div>
         </div>
     {% endblock %}

--- a/juntagrico/templates/job.html
+++ b/juntagrico/templates/job.html
@@ -138,19 +138,11 @@
                         {% trans "abgesagt" %}
                     </div>
                 {% else %}
-                    {% with slots_taken=job.occupied_slots %}
-                        <div class="col-lg-9" title="{{ slots_taken }} von {{ job.slots }} gebucht">
-                            {% spaceless %}
-                                {% for _ in ''|ljust:job.slots %}
-                                    {% if forloop.counter <= slots_taken %}
-                                        <img src="{% images "single_full" %}" alt="{% trans "Belegter Platz" %}"/>
-                                    {% else %}
-                                        <img src="{% images "single_empty" %}" alt="{% trans "Freier Platz" %}"/>
-                                    {% endif %}
-                                {% endfor %}
-                            {% endspaceless %}
-                        </div>
-                    {% endwith %}
+                    <div class="col-lg-9" title="{% blocktrans with taken=job.occupied_slots total=job.slots%}{{ taken }} von {{ total }} gebucht{% endblocktrans %}">
+                        {% block job_status %}
+                            {{ job.occupied_slots }} / {{ job.slots }}
+                        {% endblock %}
+                    </div>
                 {% endif %}
             </div>
         {% endblock %}

--- a/juntagrico/templates/juntagrico/job/modals/add_assignment.html
+++ b/juntagrico/templates/juntagrico/job/modals/add_assignment.html
@@ -1,0 +1,22 @@
+{% extends "juntagrico/modal.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}
+    {% blocktrans trimmed %}
+        Teilnehmende hinzufügen
+    {% endblocktrans %}
+{% endblock %}
+
+{% block body %}
+    <div id="{{ name }}_content">
+        <form action="{% url 'assignment-add' job.id %}" method="post" class="modal-form" id="{{ name }}_form">
+            {% crispy add_form %}
+        </form>
+    </div>
+{% endblock %}
+
+{% block buttons %}
+    <input type="submit" id="{{ name }}_submit" form="add_assignment_form" class="btn btn-primary"
+           value="{% trans "Speichern" %}">
+{% endblock %}

--- a/juntagrico/templates/juntagrico/job/modals/add_assignment.html
+++ b/juntagrico/templates/juntagrico/job/modals/add_assignment.html
@@ -14,6 +14,20 @@
             {% crispy add_form %}
         </form>
     </div>
+
+    <p>
+        <strong>
+            {% if other_job_contacts %}
+                {% blocktrans trimmed %}
+                     Kontaktpersonen werden ebenfalls automatisch informiert:
+                {% endblocktrans %}
+                <br>
+                {% for email, coordinator in other_job_contacts %}
+                    {{ coordinator|default:email }}<br>
+                {% endfor %}
+            {% endif %}
+        </strong>
+    </p>
 {% endblock %}
 
 {% block buttons %}

--- a/juntagrico/templates/juntagrico/job/snippets/participant_list.html
+++ b/juntagrico/templates/juntagrico/job/snippets/participant_list.html
@@ -1,61 +1,83 @@
+{% load crispy_forms_tags %}
 {% load juntagrico.common %}
 {% load i18n %}
-<ul>
-    {% for participant in participants %}
-        <li class="participant">
-            <span class="participant-name">{{ participant }}</span>
-            {% if participant.slots > 1 %}
-                <span class="participant-count">(+{{ participant.slots|add:"-1" }})</span>
-            {% endif %}
-            {% if participant.is_first_job %}
-                <span class="badge badge-success participant-first-time">
-                    {% blocktrans %}Erster Einsatz{% endblocktrans %}
+
+{# add people to job #}
+{% if add_form %}
+    <div class="mb-2">
+        {% spaceless %}
+            <button type="button" class="btn btn-outline-primary add-assignment">
+                <i class="bi bi-plus-lg"></i>
+                hinzufügen
+            </button>
+        {% endspaceless %}
+    </div>
+
+    {% include "../modals/add_assignment.html" with name='add_assignment' %}
+{% endif %}
+
+{% if not participants %}
+    {% trans "Noch niemand" %} 🥺
+{% else %}
+
+    <ul>
+        {% for participant in participants %}
+            <li class="participant">
+                <span class="participant-name">{{ participant }}</span>
+                {% if participant.slots > 1 %}
+                    <span class="participant-count">(+{{ participant.slots|add:"-1" }})</span>
+                {% endif %}
+                {% if participant.is_first_job %}
+                    <span class="badge badge-success participant-first-time">
+                        {% blocktrans %}Erster Einsatz{% endblocktrans %}
+                    </span>
+                {% elif participant.is_first_job_in_area %}
+                    <span class="badge badge-success participant-first-time-in-area">
+                        {% blocktrans %}Erster Einsatz im Tätigkeitsbereich{% endblocktrans %}
+                    </span>
+                {% elif participant.is_first_job_of_type %}
+                    <span class="badge badge-success participant-first-time-of-type">
+                        {% blocktrans %}Erster Einsatz dieser Art{% endblocktrans %}
+                    </span>
+                {% endif %}
+                <span class="participant-job-extras">
+                {% for extra in job.all_participant_extras|get_item:participant %}
+                    {{ extra.extra_type.display_full|safe }}
+                {% endfor %}
                 </span>
-            {% elif participant.is_first_job_in_area %}
-                <span class="badge badge-success participant-first-time-in-area">
-                    {% blocktrans %}Erster Einsatz im Tätigkeitsbereich{% endblocktrans %}
-                </span>
-            {% elif participant.is_first_job_of_type %}
-                <span class="badge badge-success participant-first-time-of-type">
-                    {% blocktrans %}Erster Einsatz dieser Art{% endblocktrans %}
-                </span>
-            {% endif %}
-            <span class="participant-job-extras">
-            {% for extra in job.all_participant_extras|get_item:participant %}
-                {{ extra.extra_type.display_full|safe }}
-            {% endfor %}
-            </span>
-            {% if can_edit_assignments %}
-                {% spaceless %}
-                    <a class="edit-assignment" href="#" data-url="{% url 'assignment-edit' job.id participant.id %}">
-                        <i class="bi bi-pencil-square"></i>
-                    </a>
-                {% endspaceless %}
-            {% endif %}
-            {% if not participant.inactive %}
-                {% if can_contact or participant.reachable_by_email %}
+                {% if can_edit_assignments %}
                     {% spaceless %}
-                        <a class="contact-member" href="{% url 'email-to-member' participant.id %}">
-                            <i class="bi bi-envelope"></i>
+                        <a class="edit-assignment" href="#" data-url="{% url 'assignment-edit' job.id participant.id %}">
+                            <i class="bi bi-pencil-square"></i>
                         </a>
                     {% endspaceless %}
                 {% endif %}
-            {% endif %}
-        </li>
-    {% endfor %}
-</ul>
+                {% if not participant.inactive %}
+                    {% if can_contact or participant.reachable_by_email %}
+                        {% spaceless %}
+                            <a class="contact-member" href="{% url 'email-to-member' participant.id %}">
+                                <i class="bi bi-envelope"></i>
+                            </a>
+                        {% endspaceless %}
+                    {% endif %}
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ul>
 
-{# button to contact all #}
-{% if can_contact %}
-    {% block send_mail %}
-        <a href="{% url 'email-to-job' job.id %}" class="btn btn-secondary">
-            <i class="bi bi-envelope"></i>
-            {% trans "Allen ein E-Mail senden" %}
-        </a>
-    {% endblock %}
-{% endif %}
+    {# button to contact all #}
+    {% if can_contact %}
+        {% block send_mail %}
+            <a href="{% url 'email-to-job' job.id %}" class="btn btn-secondary">
+                <i class="bi bi-envelope"></i>
+                {% trans "Allen ein E-Mail senden" %}
+            </a>
+        {% endblock %}
+    {% endif %}
 
-{# Modal for editing assignment #}
-{% if can_edit_assignments %}
-    {% include "./modal_edit_assignment.html" with name='edit_assignment' %}
+    {# Modal for editing assignment #}
+    {% if can_edit_assignments %}
+        {% include "./modal_edit_assignment.html" with name='edit_assignment' %}
+    {% endif %}
+
 {% endif %}

--- a/juntagrico/templates/juntagrico/mails/admin/assignment/added.txt
+++ b/juntagrico/templates/juntagrico/mails/admin/assignment/added.txt
@@ -1,0 +1,6 @@
+{% extends "juntagrico/mails/admin/job/signup.txt" %}
+{% load i18n %}
+{% block intro %}{% blocktrans %}Soeben wurde {{ member }} von {{ editor }} zu einem Einsatz angemeldet.{% endblocktrans %}{% endblock %}
+{% block count %}{% blocktrans %}Anzahl Personen: {{ count }}{% endblocktrans %}{% endblock %}
+{% block email %}{% blocktrans %}Email von {{ editor }}{% endblocktrans %}: {{ editor.email }}
+{% blocktrans %}Email von {{ member }}{% endblocktrans %}: {{ member.email }}{% endblock %}

--- a/juntagrico/templates/juntagrico/mails/member/assignment/added.txt
+++ b/juntagrico/templates/juntagrico/mails/member/assignment/added.txt
@@ -1,0 +1,20 @@
+{% extends "juntagrico/mails/member/job/subscription_changed.txt" %}
+{% load i18n %}
+{% load juntagrico.config %}
+{% config "organisation_name" as c_organisation_name %}
+
+{% block intro %}{% blocktrans trimmed with e=editor jtg=job.type.get_name jt=job.time|date:"d.m.Y H:i" jet=job.end_time|date:"H:i" %}
+{{ e }} hat dich für den {{ c_organisation_name }}-Arbeitseinsatz "{{ jtg }}" um {{ jt }}-{{ jet }} angemeldet.
+{% endblocktrans %}
+{% blocktrans trimmed with e=editor %}
+Falls das ein Irrtum war, antworte auf dieses E-Mail um {{ e }} zu kontaktieren.
+{% endblocktrans %}
+{% endblock %}
+
+{% block slots %}
+{% if count == 1 %}
+{% trans "Du kommst allein zum Einsatz." %}
+{% else %}
+{% blocktrans with other_count=count|add:"-1" %}Du kommst mit {{ other_count }} weiteren Personen zum Einsatz.{% endblocktrans %}
+{% endif %}
+{% endblock %}

--- a/juntagrico/templatetags/juntagrico/snippets.py
+++ b/juntagrico/templatetags/juntagrico/snippets.py
@@ -5,6 +5,7 @@ from impersonate.helpers import check_allow_for_user
 
 from juntagrico.config import Config
 from juntagrico.entity.jobs import Job, RecuringJob
+from juntagrico.forms.job import AddAssignmentForm
 
 register = template.Library()
 
@@ -34,6 +35,7 @@ def job_participant_list(user, job):
         'participants': participants,
         'can_contact': permissions.can_contact_member(),
         'can_edit_assignments': permissions.can_modify_assignments(),
+        'add_form': AddAssignmentForm(job) if permissions.can_add_assignments() else None,
     }
 
 

--- a/juntagrico/templatetags/juntagrico/snippets.py
+++ b/juntagrico/templatetags/juntagrico/snippets.py
@@ -36,6 +36,7 @@ def job_participant_list(user, job):
         'can_contact': permissions.can_contact_member(),
         'can_edit_assignments': permissions.can_modify_assignments(),
         'add_form': AddAssignmentForm(job) if permissions.can_add_assignments() else None,
+        'other_job_contacts': job.get_emails(get_member=True, exclude=[user.member.email]),
     }
 
 

--- a/juntagrico/tests/test_jobs.py
+++ b/juntagrico/tests/test_jobs.py
@@ -20,10 +20,13 @@ class JobTests(JuntagricoTestCase):
         self.assertGet(reverse('jobs-all'))
 
     def testJob(self):
-        self.assertGet(reverse('job', args=[self.job1.pk]))
+        job1_url = reverse('job', args=[self.job1.pk])
+        self.assertGet(job1_url)
+        self.assertGet(job1_url, member=self.area_admin)
+        self.assertGet(job1_url, member=self.admin)
         self.assertGet(reverse('job', args=[self.one_time_job1.pk]))
         self.assertGet(reverse('job', args=[self.canceled_job.pk]))
-
+        
     def testPastJob(self):
         self.assertGet(reverse('memberjobs'))
         self.assertGet(reverse('job', args=[self.past_job.pk]))
@@ -333,6 +336,49 @@ class AssignmentTests(JuntagricoTestCase):
         self.assertPost(reverse('assignment-edit', args=[self.job2.pk, self.member.pk]), {'slots': 2},
                         403, self.member2)
         self.assertEqual(self.job2.occupied_slots, 1)
+        self.assertPost(
+            reverse('assignment-add', args=[self.job2.pk]),
+            {'account': self.member3.pk, 'slots': 1},
+            403,
+            self.member2,
+        )
+
+    def testAssignmentAdd(self, admin=None, participant=None):
+        admin = admin or self.member  # has general permission to change assignments
+        participant = participant or self.member3
+        self.signal_called = False
+
+        @receiver(assignment_changed, sender=Member)
+        def handler(instance, job, count, *args, **kwargs):
+            self.signal_called = True
+            self.assertEqual(count, 1)
+            self.assertEqual(job, self.job2)
+            self.assertEqual(instance.pk, participant.pk)
+
+        self.assertGet(reverse('job', args=[self.job2.pk]), member=admin)
+        # test add participant
+        self.assertPost(reverse('assignment-add', args=[self.job2.pk]),
+                        {'add-account': participant.pk, 'add-slots': 1}, 302, admin)
+        self.assertEqual(self.job2.occupied_slots, 2)
+        self.assertSetEqual(self.job2.participant_emails, {self.member.email, participant.email})
+        self.assertTrue(self.signal_called)
+        self.assertEqual(len(mail.outbox), 2 if admin != participant else 1)  # (member notification +) admin notification
+        if admin != participant:
+            # if member edits their own assignment, no notification is sent to them
+            self.assertEqual(mail.outbox[0].recipients(), [participant.email])
+        self.assertEqual(mail.outbox[-1].recipients(), ['email_contact@example.org'])
+        self.assertIn(participant.email, mail.outbox[-1].body, 'Admin notification must contain members email address')
+        mail.outbox.clear()
+        self.assertTrue(assignment_changed.disconnect(handler, sender=Member))
+
+    def testAssignmentAddBySelf(self):
+        self.testAssignmentAdd(self.area_admin, self.area_admin)
+
+    def testAssignmentAddByCoordinator(self):
+        self.testAssignmentAdd(self.area_admin)
+
+    def testAssignmentAddByAssignmentModifier(self):
+        self.testAssignmentAdd(self.area_admin_assignment_modifier)
 
     def testAssignmentEdit(self, admin=None):
         admin = admin or self.member  # has general permission to change assignments

--- a/juntagrico/urls.py
+++ b/juntagrico/urls.py
@@ -108,6 +108,7 @@ urlpatterns = [
 
     # /assignment
     path('assignment/<int:job_id>/<int:member_id>/edit', job.edit_assignment, name='assignment-edit'),
+    path('assignment/<int:job_id>/add', job.add_assignment, name='assignment-add'),
 
     # /area
     path('my/areas', juntagrico.areas, name='areas'),

--- a/juntagrico/views/job.py
+++ b/juntagrico/views/job.py
@@ -14,7 +14,12 @@ from juntagrico.dao.jobdao import JobDao
 from juntagrico.entity.jobs import Job, Assignment, JobExtra, ActivityArea, OneTimeJob, RecuringJob, JobType
 from juntagrico.entity.member import Member
 from juntagrico.forms import BusinessYearForm
-from juntagrico.forms.job import JobSubscribeForm, EditAssignmentForm, ConvertToRecurringJobForm
+from juntagrico.forms.job import (
+    JobSubscribeForm,
+    EditAssignmentForm,
+    ConvertToRecurringJobForm,
+    AddAssignmentForm,
+)
 from juntagrico.util import return_to_previous_location
 from juntagrico.view_decorators import highlighted_menu
 
@@ -300,3 +305,23 @@ def edit_assignment(request, job_id, member_id, form_class=EditAssignmentForm, r
         'form': form,
         'success': success,
     })
+
+
+@login_required
+def add_assignment(request, job_id, form_class=AddAssignmentForm):
+    job = get_object_or_404(Job, id=int(job_id))
+    # check permission
+    is_assignment_coordinator = job.check_if(request.user).is_assignment_coordinator
+    if not (is_assignment_coordinator
+            or request.user.has_perm('juntagrico.add_assignment')):
+        raise PermissionDenied
+
+    if request.method == 'POST':
+        form = form_class(job, request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, mark_safe('<i class="bi bi-check2-circle"></i> ' +
+                                                    _("Erfolgreich hinzugefügt")))
+        else:
+            messages.error(request, _('Hinzufügen fehlgeschlagen.'))
+    return redirect('job', job_id=job_id)

--- a/juntagrico/views/job.py
+++ b/juntagrico/views/job.py
@@ -317,7 +317,7 @@ def add_assignment(request, job_id, form_class=AddAssignmentForm):
         raise PermissionDenied
 
     if request.method == 'POST':
-        form = form_class(job, request.POST)
+        form = form_class(job, request.POST, editor=request.user.member)
         if form.is_valid():
             form.save()
             messages.success(request, mark_safe('<i class="bi bi-check2-circle"></i> ' +

--- a/juntagrico/views/job.py
+++ b/juntagrico/views/job.py
@@ -307,6 +307,7 @@ def edit_assignment(request, job_id, member_id, form_class=EditAssignmentForm, r
     })
 
 
+@require_POST
 @login_required
 def add_assignment(request, job_id, form_class=AddAssignmentForm):
     job = get_object_or_404(Job, id=int(job_id))
@@ -316,12 +317,11 @@ def add_assignment(request, job_id, form_class=AddAssignmentForm):
             or request.user.has_perm('juntagrico.add_assignment')):
         raise PermissionDenied
 
-    if request.method == 'POST':
-        form = form_class(job, request.POST, editor=request.user.member)
-        if form.is_valid():
-            form.save()
-            messages.success(request, mark_safe('<i class="bi bi-check2-circle"></i> ' +
-                                                    _("Erfolgreich hinzugefügt")))
-        else:
-            messages.error(request, _('Hinzufügen fehlgeschlagen.'))
+    form = form_class(job, request.POST, editor=request.user.member)
+    if form.is_valid():
+        form.save()
+        messages.success(request, mark_safe('<i class="bi bi-check2-circle"></i> ' +
+                                                _("Erfolgreich hinzugefügt")))
+    else:
+        messages.error(request, _('Hinzufügen fehlgeschlagen.'))
     return redirect('job', job_id=job_id)


### PR DESCRIPTION
# Description
Implements #868.
On duplicate names, the join date of the member is displayed to differentiate. Same as in the email form.

# TODO
- [x] Jobs can be overbooked now. Fix the status display as described in #488
- [x] Notify added participant via email.
- [x] write tests

