### PR TITLE
fix assignment by area export

### DIFF
--- a/docs/reference/exports.rst
+++ b/docs/reference/exports.rst
@@ -5,6 +5,18 @@ Exports
 
 Juntagrico uses `django_import_export <https://django-import-export.readthedocs.io/en/stable/>`_ to provide customizable data exports.
 
+Export Formats
+--------------
+
+All formats supported by `tablib <https://tablib.readthedocs.io/en/stable/formats.html>`_ can be used for export.
+Some formats have additional dependencies. Add these to you ``requirements.txt`` if you want to export in these formats:
+
+- xlsx: ``openpyxl>=2.6.0``
+- xls: ``xlwt``
+- ods: ``odfpy``
+- yaml: ``pyyaml``
+
+
 Add Export
 ----------
 

--- a/juntagrico/resources/__init__.py
+++ b/juntagrico/resources/__init__.py
@@ -1,3 +1,22 @@
+from import_export import resources
+
+
+class ModQuerysetModelResource(resources.ModelResource):
+    """
+    ModelResource with modifiable queryset
+    DEPRECATED since juntagrico 2.0
+    """
+    def update_queryset(self, queryset):
+        return queryset
+
+    def get_queryset(self):
+        print('ModQuerysetModelResource is deprecated: Use normal resources.ModelResource and define filter_queryset instead.')
+        return self.update_queryset(super().get_queryset())
+
+    def export(self, queryset=None, *args, **kwargs):
+        if queryset is not None:
+            queryset = self.update_queryset(queryset)
+        return super().export(queryset, *args, **kwargs)
 
 
 class DateRangeResourceMixin:

--- a/juntagrico/resources/__init__.py
+++ b/juntagrico/resources/__init__.py
@@ -1,20 +1,3 @@
-from import_export import resources
-
-
-class ModQuerysetModelResource(resources.ModelResource):
-    """
-    ModelResource with modifiable queryset
-    """
-    def update_queryset(self, queryset):
-        return queryset
-
-    def get_queryset(self):
-        return self.update_queryset(super().get_queryset())
-
-    def export(self, queryset=None, *args, **kwargs):
-        if queryset is not None:
-            queryset = self.update_queryset(queryset)
-        return super().export(queryset, *args, **kwargs)
 
 
 class DateRangeResourceMixin:

--- a/juntagrico/resources/member.py
+++ b/juntagrico/resources/member.py
@@ -1,13 +1,13 @@
 from django.utils.translation import gettext as _
-
 from import_export import resources
+
 from import_export.fields import Field
 from import_export.widgets import ManyToManyWidget, DecimalWidget
 
 from ..entity.jobs import ActivityArea, Job
 from ..entity.member import Member
 from ..config import Config
-from . import ModQuerysetModelResource, DateRangeResourceMixin
+from . import DateRangeResourceMixin
 
 
 class MemberResource(resources.ModelResource):
@@ -27,13 +27,13 @@ class MemberResource(resources.ModelResource):
         name = Config.vocabulary('member_pl')
 
 
-class MemberWithAssignmentsAndAreaResource(DateRangeResourceMixin, ModQuerysetModelResource):
+class MemberWithAssignmentsAndAreaResource(DateRangeResourceMixin, resources.ModelResource):
     depot = Field('subscription_current__depot__name', 'depot', readonly=True)
     areas = Field('areas', widget=ManyToManyWidget(ActivityArea, field='name'), readonly=True)
     assignment_count = Field('assignment_count', widget=DecimalWidget(), readonly=True)
     core_assignment_count = Field('core_assignment_count', widget=DecimalWidget(), readonly=True)
 
-    def update_queryset(self, queryset):
+    def filter_export(self, queryset, **kwargs):
         return queryset.annotate_all_assignment_count(self.start_date, self.end_date)
 
     class Meta:
@@ -45,23 +45,26 @@ class MemberWithAssignmentsAndAreaResource(DateRangeResourceMixin, ModQuerysetMo
                                                                   Config.vocabulary('assignment_pl'))
 
 
-class MemberAssignmentsPerArea(DateRangeResourceMixin, ModQuerysetModelResource):
+class MemberAssignmentsPerArea(DateRangeResourceMixin, resources.ModelResource):
     name = Field('get_name', 'name')
 
-    def get_fields(self):
+    def before_export(self, queryset, **kwargs):
         # create a field for each area dynamically
-        self.fields.update({
-            area.name: Field(f'{area.id}assignment_count', area.name)
-            for area in ActivityArea.objects.all()
-        })
-        return super().get_fields()
+        self.fields.update(
+            {
+                area.name: Field(f'{area.id}assignment_count', area.name)
+                for area in ActivityArea.objects.all()
+            }
+        )
+        kwargs['export_fields'] += [area.name for area in ActivityArea.objects.all()]
 
-    def update_queryset(self, queryset):
+    def filter_export(self, queryset, **kwargs):
         for area in ActivityArea.objects.all():
             queryset = queryset.annotate_assignment_count(
-                self.start_date, self.end_date,
+                self.start_date,
+                self.end_date,
                 prefix=str(area.id),
-                assignment__job__in=Job.objects.in_area(area)
+                assignment__job__in=Job.objects.in_area(area),
             )
         return queryset
 

--- a/juntagrico/resources/share.py
+++ b/juntagrico/resources/share.py
@@ -1,11 +1,11 @@
+from import_export import resources
 from import_export.fields import Field
 
-from . import ModQuerysetModelResource
 from ..config import Config
 from ..entity.share import Share
 
 
-class ShareResource(ModQuerysetModelResource):
+class ShareResource(resources.ModelResource):
     member_first_name = Field('member__first_name')
     member_last_name = Field('member__last_name')
     member_email = Field('member__email')

--- a/juntagrico/resources/subscription.py
+++ b/juntagrico/resources/subscription.py
@@ -1,12 +1,13 @@
+from import_export import resources
 from import_export.fields import Field
 from import_export.widgets import DecimalWidget, IntegerWidget
 
-from . import ModQuerysetModelResource, DateRangeResourceMixin
+from . import DateRangeResourceMixin
 from ..config import Config
 from ..entity.subs import Subscription, SubscriptionPart
 
 
-class SubscriptionResource(DateRangeResourceMixin, ModQuerysetModelResource):
+class SubscriptionResource(DateRangeResourceMixin, resources.ModelResource):
     content = Field('size')
 
     status = Field('state_text')
@@ -28,7 +29,7 @@ class SubscriptionResource(DateRangeResourceMixin, ModQuerysetModelResource):
     core_assignments_progress = Field('core_assignments_progress', widget=DecimalWidget(coerce_to_string=False))
     price = Field('price', widget=DecimalWidget())
 
-    def update_queryset(self, queryset):
+    def filter_export(self, queryset, **kwargs):
         return queryset.annotate_assignments_progress(self.start_date, self.end_date)
 
     def dehydrate_co_members(self, subscription):
@@ -48,12 +49,12 @@ class SubscriptionResource(DateRangeResourceMixin, ModQuerysetModelResource):
         name = Config.vocabulary('subscription_pl')
 
 
-class SubscriptionPartResource(ModQuerysetModelResource):
+class SubscriptionPartResource(resources.ModelResource):
     type_name = Field('type__name')
     subscription_id = Field('subscription__pk', widget=IntegerWidget(coerce_to_string=False))
     is_extra = Field('type__is_extra')
 
-    def update_queryset(self, queryset):
+    def filter_export(self, queryset, **kwargs):
         return SubscriptionPart.objects.filter(subscription__in=queryset)
 
     class Meta:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ version = {attr = "juntagrico.__version__"}
 select = ["E", "F", "B"]
 ignore = ["E501"]
 
+[tool.ruff.format]
+quote-style = "single"
+
 [tool.coverage.run]
 plugins = ["django_coverage_plugin"]
 include = ["juntagrico/*", "juntagrico_legacy/*"]


### PR DESCRIPTION
- `get_fields` method was removed in django import export. Use new `before_export` hook to add fields dynamically.
- depreate `ModQuerysetModelResource`. Django-import-export>4 supports updating the queryset using the `filter_export` hook.

