### PR TITLE
Rename confusing button during subscription

### DIFF
--- a/juntagrico/forms/__init__.py
+++ b/juntagrico/forms/__init__.py
@@ -261,7 +261,7 @@ class RegisterMemberForm(MemberBaseForm):
             'comment',
             'agb',
             FormActions(
-                Submit('submit', _('Anmelden'), css_class='btn-success'),
+                Submit('submit', _('Weiter'), css_class='btn-success'),
             )
         )
         self.fields['email'].error_messages['unique'] = self.duplicate_email_message()

--- a/juntagrico/forms/__init__.py
+++ b/juntagrico/forms/__init__.py
@@ -250,7 +250,8 @@ class RegisterMemberForm(MemberBaseForm):
         'accept_wo_docs': gettext_lazy(
             'Ich erkläre meinen Willen, "{organization}" beizutreten. Hiermit beantrage ich meine Aufnahme.'
         ),
-        'and': gettext_lazy('und')
+        'and': gettext_lazy('und'),
+        'submit': gettext_lazy('Weiter'),
     }
 
     def __init__(self, *args, **kwargs):
@@ -261,7 +262,7 @@ class RegisterMemberForm(MemberBaseForm):
             'comment',
             'agb',
             FormActions(
-                Submit('submit', _('Weiter'), css_class='btn-success'),
+                Submit('submit', self.text['submit'], css_class='btn-success'),
             )
         )
         self.fields['email'].error_messages['unique'] = self.duplicate_email_message()

--- a/juntagrico/views/create_subscription.py
+++ b/juntagrico/views/create_subscription.py
@@ -173,7 +173,7 @@ def create_external(request):
                    'agb': post_data['by_laws_accepted'],
                    'mobile_phone': '',
                    'birthday': '',
-                   'submit': 'Weiter zur Aboauswahl',
+                   'submit': 'Anmelden',
                    'comment': post_data['comment'] + '[External signup API]'
                    }
     signup_manager.set('main_member', main_member)

--- a/juntagrico/views/create_subscription.py
+++ b/juntagrico/views/create_subscription.py
@@ -173,7 +173,7 @@ def create_external(request):
                    'agb': post_data['by_laws_accepted'],
                    'mobile_phone': '',
                    'birthday': '',
-                   'submit': 'Anmelden',
+                   'submit': 'Weiter zur Aboauswahl',
                    'comment': post_data['comment'] + '[External signup API]'
                    }
     signup_manager.set('main_member', main_member)


### PR DESCRIPTION
To that point the members are not "angemeldet" yet, so we should rather indicate the next step of the subscription on the button.