### PR TITLE
admin: implement cumulative shares option #623

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -440,6 +440,7 @@ MEMBERSHIP
   The setting takes a dictionary of key-value pairs:
     - ``'enable'``: enable all membership related functions (Bool)
     - ``'required_shares'``: amount of shares required for a membership (Integer)
+    - [New since version 2.1] ``'cumulative_shares'``: If true shares count either for membership or for subscription, not both (Bool)
     - ``'required_on_signup'``: whether a membership is mandatory to signup up (Bool)
     - ``'fee'``: yearly membership fee (Float, Integer or String)
 
@@ -450,6 +451,7 @@ MEMBERSHIP
         {
             'enable': True,
             'required_shares': 1,
+            'cumulative_shares': False,
             'required_on_signup': True,
             'fee': 0,
         }

--- a/juntagrico/admins/inlines/subscription_part_inlines.py
+++ b/juntagrico/admins/inlines/subscription_part_inlines.py
@@ -18,7 +18,7 @@ class SubscriptionPartInlineFormset(BaseInlineFormSet):
                 required_shares += form.instance.type.shares
                 future_parts_count += 1 if form.instance.cancellation_date is None else 0
         if Config.enable_shares():
-            available_shares = sum([member.usable_shares_count for member in self.instance.future_members])
+            available_shares = sum([member.usable_shares_for_sub_count for member in self.instance.future_members])
             if required_shares > available_shares:
                 raise ValidationError(
                     _('Nicht genug {0} vorhanden. Vorhanden {1}. Benötigt {2}').format(Config.vocabulary('share_pl'),

--- a/juntagrico/config.py
+++ b/juntagrico/config.py
@@ -142,6 +142,7 @@ class Config:
         {
             'enable': True,
             'required_shares': 1,
+            'cumulative_shares': False,
             'required_on_signup': True,
             'fee': 0,
         }
@@ -150,6 +151,10 @@ class Config:
     @classmethod
     def enable_membership(cls):
         return cls.membership('enable')
+
+    @classmethod
+    def cumulative_shares_for_membership(cls):
+        return cls.membership('enable') and cls.membership('cumulative_shares') and cls.membership('required_shares') > 0
 
     required_shares = _get_setting('REQUIRED_SHARES', 1)
     enable_registration = _get_setting('ENABLE_REGISTRATION', True)

--- a/juntagrico/dao/sharedao.py
+++ b/juntagrico/dao/sharedao.py
@@ -10,6 +10,7 @@ class ShareDao:
 
     @staticmethod
     def all_shares_subscription(subscription):
+        print('ShareDao.all_shares_subscription is deprecated: Use subscription.available_shares instead')
         return Share.objects.filter(member__in=subscription.current_members).filter(
             cancelled_date__isnull=True)
 

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext, gettext_lazy as _
 
 from juntagrico.config import Config
 from juntagrico.entity import JuntagricoBaseModel, notifiable, LowercaseEmailField, validate_iban
+from juntagrico.entity.share import Share
 from juntagrico.lifecycle.member import check_member_consistency
 from juntagrico.lifecycle.submembership import check_sub_membership_consistency
 from juntagrico.queryset.member import MemberQuerySet
@@ -117,6 +118,8 @@ class Member(JuntagricoBaseModel):
     @property
     def shares(self):
         """ forward compatibility """
+        if not self.pk:
+            Share.objects.none()
         return self.share_set
 
     @property
@@ -168,9 +171,24 @@ class Member(JuntagricoBaseModel):
         return self.usable_shares.count()
 
     @property
+    def usable_shares_for_sub_count(self):
+        usable = self.shares.usable().count()
+        if Config.cumulative_shares_for_membership() and self.memberships.not_canceled().exists():
+            usable -= Config.membership('required_shares')
+        return usable
+
+    @property
+    def usable_shares_for_membership_count(self):
+        usable = self.shares.usable().count()
+        if Config.cumulative_shares_for_membership():
+            usable -= self.required_shares_count()
+        return usable
+
+    @property
     def required_shares_count(self):
+        """ shares required for subscription"""
         # calculate required shares backwards to account for shared subscriptions
-        not_canceled_share_count = self.usable_shares_count
+        not_canceled_share_count = self.usable_shares_for_sub_count
         overflow_list = [not_canceled_share_count]
         if self.subscription_future is not None:
             overflow_list.append(self.subscription_future.share_overflow)
@@ -181,10 +199,14 @@ class Member(JuntagricoBaseModel):
     @property
     def cancellable_shares_count(self):
         is_member = Config.membership('enable') and self.memberships.not_canceled().exists()
-        required_shares = max(
+        if Config.cumulative_shares_for_membership():
+            aggregate = sum
+        else:
+            aggregate = max
+        required_shares = aggregate((
             self.required_shares_count,
             Config.membership('required_shares') if is_member else 0,
-        )
+        ))
         return self.shares.usable().count() - required_shares
 
     @property
@@ -226,6 +248,7 @@ class Member(JuntagricoBaseModel):
             subscription.save()
 
     def leave_subscription(self, subscription=None, changedate=None):
+        print('Member.leave_subscription is deprecated: Use SubscriptionMembership.leave instead')
         subscription = subscription or self.subscription_current
         if subscription == self.subscription_current:
             del self.subscription_current  # clear cache

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -181,7 +181,7 @@ class Member(JuntagricoBaseModel):
     def usable_shares_for_membership_count(self):
         usable = self.shares.usable().count()
         if Config.cumulative_shares_for_membership():
-            usable -= self.required_shares_count()
+            usable -= self.required_shares_count
         return usable
 
     @property

--- a/juntagrico/entity/member.py
+++ b/juntagrico/entity/member.py
@@ -190,8 +190,9 @@ class Member(JuntagricoBaseModel):
         # calculate required shares backwards to account for shared subscriptions
         not_canceled_share_count = self.usable_shares_for_sub_count
         overflow_list = [not_canceled_share_count]
-        if self.subscription_future is not None:
-            overflow_list.append(self.subscription_future.share_overflow)
+        future_subscription = self.subscription_future
+        if future_subscription is not None and future_subscription.waiting:
+            overflow_list.append(future_subscription.share_overflow)
         if self.subscription_current is not None:
             overflow_list.append(self.subscription_current.share_overflow)
         return not_canceled_share_count - min(overflow_list)

--- a/juntagrico/entity/subs.py
+++ b/juntagrico/entity/subs.py
@@ -12,6 +12,8 @@ from juntagrico.dao.sharedao import ShareDao
 from juntagrico.entity import notifiable, JuntagricoBaseModel, SimpleStateModel
 from juntagrico.entity.billing import Billable
 from juntagrico.entity.depot import Depot
+from juntagrico.entity.membership import Membership
+from juntagrico.entity.share import Share
 from juntagrico.lifecycle.sub import check_sub_consistency, check_sub_reactivation
 from juntagrico.lifecycle.subpart import check_sub_part_consistency
 from juntagrico.mailer import adminnotification
@@ -152,7 +154,20 @@ class Subscription(Billable, SimpleStateModel):
 
     @property
     def all_shares(self):
+        print('Subscription.all_shares is deprecated: Use available_shares instead')
         return ShareDao.all_shares_subscription(self).count()
+
+    @property
+    def available_shares(self):
+        """amount of shares dedicated to subscription"""
+        current_members = self.current_members
+        share_count = Share.objects.filter(member__in=current_members).usable().count()
+        if Config.cumulative_shares_for_membership():
+            # if cumulative, subtract shares that are needed for membership
+            share_count -= Membership.objects.filter(
+                account__in=current_members
+            ).not_canceled().count() * Config.membership('required_shares')
+        return share_count
 
     @property
     def paid_shares(self):
@@ -160,7 +175,7 @@ class Subscription(Billable, SimpleStateModel):
 
     @property
     def share_overflow(self):
-        return self.all_shares - self.required_shares
+        return self.available_shares - self.required_shares
 
     @property
     def required_shares(self):

--- a/juntagrico/forms/__init__.py
+++ b/juntagrico/forms/__init__.py
@@ -523,7 +523,7 @@ class SubscriptionPartOrderForm(SubscriptionPartBaseForm):
             )
         # check if members in subscription have sufficient shares
         if Config.enable_shares():
-            available_shares = self.subscription.all_shares
+            available_shares = self.subscription.available_shares
             new_required_shares = sum([sub_type.shares * amount for sub_type, amount in selected.items()])
             existing_required_shares = self.subscription.required_shares
             if available_shares < new_required_shares + existing_required_shares:
@@ -594,7 +594,7 @@ class SubscriptionPartChangeForm(SubscriptionPartBaseForm):
             sub_type = SubscriptionType.objects.get(id=selected)
             # check if members in subscription have sufficient shares
             if Config.enable_shares():
-                additional_available_shares = self.part.subscription.all_shares - self.part.subscription.required_shares
+                additional_available_shares = self.part.subscription.available_shares - self.part.subscription.required_shares
                 additional_required_shares = sub_type.shares - self.part.type.shares
                 if additional_available_shares < additional_required_shares:
                     share_error_message = mark_safe(

--- a/juntagrico/forms/account.py
+++ b/juntagrico/forms/account.py
@@ -199,6 +199,8 @@ class CancellationForm(forms.ModelForm):
         if Config.enable_shares() and 'shares' in self.fields:
             usable_shares = self.usable_shares.count()
             remaining_shares = usable_shares - cleaned_data.get('shares', 0)
+
+            required_for_subscription = 0
             if self.primary_subscriptions or self.co_memberships:
                 required_for_subscription = max(
                     *(
@@ -213,6 +215,29 @@ class CancellationForm(forms.ModelForm):
                     ),
                     0, 0
                 )
+
+            required_for_membership = 0
+            if Config.membership('enable') and cleaned_data.get('membership'):
+                required_for_membership = Config.membership('required_shares')
+            
+            if Config.cumulative_shares_for_membership():
+                total_required = required_for_subscription + required_for_membership
+                if remaining_shares < total_required:
+                    self.add_error(
+                        'shares',
+                        ngettext(
+                            'Es wird noch {num} {share} für {your_subscription_acc} und {your_membership_acc} benötigt.',
+                            'Es werden noch {num} {shares} für {your_subscription_acc} und {your_membership_acc} benötigt.',
+                            total_required
+                        ).format(
+                            num=total_required,
+                            your_subscription_acc=Config.vocabulary('your_subscription_acc'),
+                            your_membership_acc=Config.vocabulary('your_membership_acc'),
+                            share=Config.vocabulary('share'),
+                            shares=Config.vocabulary('share_pl'),
+                        )
+                    )
+            else:
                 if remaining_shares < required_for_subscription:
                     self.add_error(
                         'shares',
@@ -227,8 +252,6 @@ class CancellationForm(forms.ModelForm):
                             shares=Config.vocabulary('share_pl'),
                         )
                     )
-            if Config.membership('enable') and cleaned_data.get('membership'):
-                required_for_membership = Config.membership('required_shares')
                 if remaining_shares < required_for_membership:
                     self.add_error(
                         'shares',

--- a/juntagrico/tests/__init__.py
+++ b/juntagrico/tests/__init__.py
@@ -77,14 +77,15 @@ class JuntagricoTestCase(TestCase):
         member_data.update(kwargs)
         member = Member.objects.create(**member_data)
         if with_membership:
-            membership_data = {
-                'activation_date': '2026-03-12',
-                'number': 1
-            }
-            if isinstance(with_membership, dict):
-                membership_data |= with_membership
-            Membership.objects.create(account=member, **membership_data)
+            args = with_membership if isinstance(with_membership, dict) else {}
+            JuntagricoTestCase.create_membership(member, **args)
         return member
+
+    @staticmethod
+    def create_membership(account, **kwargs):
+        membership_data = {'activation_date': '2026-03-12', 'number': 1}
+        membership_data |= kwargs
+        return Membership.objects.create(account=account, **membership_data)
 
     @staticmethod
     def create_paid_share(member, **kwargs):

--- a/juntagrico/tests/test_cs.py
+++ b/juntagrico/tests/test_cs.py
@@ -12,6 +12,8 @@ from ..config import Config
 
 
 class CreateSubscriptionTests(JuntagricoTestCase):
+    share_order_count = 1
+    
     @staticmethod
     def newMemberData(email='test@user.com'):
         return {
@@ -111,7 +113,7 @@ class CreateSubscriptionTests(JuntagricoTestCase):
             response = self.client.post(
                 reverse('cs-shares'),
                 {
-                    'of_member': 1,
+                    'of_member': self.share_order_count,
                     'of_co_member[0]': 0,
                 }
             )
@@ -126,7 +128,10 @@ class CreateSubscriptionTests(JuntagricoTestCase):
         self.assertRedirects(response, reverse('welcome-with-sub'))
         self.assertEqual(Member.objects.filter(email=member_email).count(), 1)
         if settings.ENABLE_SHARES:
-            self.assertEqual(Share.objects.filter(member__email=member_email).count(), initial_share_count + 1)
+            self.assertEqual(
+                Share.objects.filter(member__email=member_email).count(),
+                initial_share_count + self.share_order_count,
+            )
         subscription = Subscription.objects.filter(primary_member__email=member_email).first()
         self.assertNotEqual(subscription, None)
         # look for comment in admin notification
@@ -148,7 +153,7 @@ class CreateSubscriptionTests(JuntagricoTestCase):
         if with_co_member:
             mail_count += 2  # Welcome to co-member & admin notification
         if settings.ENABLE_SHARES:
-            mail_count += 2  # share email & admin notification
+            mail_count += 1 + self.share_order_count  # share email & admin notification(s)
             # no shares are ordered for co-member, thus no more emails
         self.assertEqual(len(mail.outbox), mail_count)
 
@@ -198,17 +203,27 @@ class CreateSubscriptionTests(JuntagricoTestCase):
         """ test order of new sub by existing member without sub
         """
         self.client.force_login(self.member4.user)
-        self.commonAddSub(self.member4.email, True, 'test comment', 3 if settings.ENABLE_SHARES else 1)
+        self.commonAddSub(
+            self.member4.email,
+            True,
+            'test comment',
+            (2 + self.share_order_count) if settings.ENABLE_SHARES else 1,
+        )
         # share mail (if enabled) for member & welcome mail for co-member & 3 admin notifications
-        self.assertEqual(len(mail.outbox), 5 if settings.ENABLE_SHARES else 3)
+        self.assertEqual(len(mail.outbox), (4 + self.share_order_count) if settings.ENABLE_SHARES else 3)
 
     def testAddSubWithoutComember(self):
         """ test order of new sub by existing member without sub
         """
         self.client.force_login(self.member4.user)
-        self.commonAddSub(self.member4.email, False, 'test comment', 2 if settings.ENABLE_SHARES else 0)
+        self.commonAddSub(
+            self.member4.email,
+            False,
+            'test comment',
+            (1 + self.share_order_count) if settings.ENABLE_SHARES else 0,
+        )
         # share mails (if enabled) for member & admin + 1 admin notification on new subscription
-        self.assertEqual(len(mail.outbox), 3 if settings.ENABLE_SHARES else 1)
+        self.assertEqual(len(mail.outbox), (2 + self.share_order_count) if settings.ENABLE_SHARES else 1)
 
     def testSignupWithComment(self):
         self.commonSignupTest(False, True)
@@ -294,7 +309,7 @@ class CreateSubscriptionTests(JuntagricoTestCase):
             response = self.client.post(
                 reverse('cs-shares'),
                 {
-                    'of_member': 1,
+                    'of_member': self.share_order_count,
                     'of_co_member[0]': 1,
                 }
             )
@@ -367,3 +382,8 @@ class CreateSubscriptionWithoutExtrasTests(CreateSubscriptionTests):
 @override_settings(MEMBERSHIP={'enable': False})
 class CreateSubscriptionWithoutMembershipsTests(CreateSubscriptionTests):
     pass
+
+
+@override_settings(MEMBERSHIP={'cumulative_shares': True})
+class CreateSubscriptionWithCumulativeSharesTests(CreateSubscriptionTests):
+    share_order_count = 2

--- a/juntagrico/tests/test_membership.py
+++ b/juntagrico/tests/test_membership.py
@@ -158,6 +158,11 @@ class MembershipTests(JuntagricoTestCase):
             self.assertEqual(member.inactive, result, f'{member} {member.email}')
 
 
+@override_settings(MEMBERSHIP={'cumulative_shares': True})
+class MembershipWithCumulativeSharesTest(MembershipTests):
+    pass
+
+
 class MembershipAdminTests(JuntagricoTestCase):
     @classmethod
     def setUpTestData(cls):

--- a/juntagrico/tests/test_shares.py
+++ b/juntagrico/tests/test_shares.py
@@ -7,6 +7,7 @@ from django.test import tag, override_settings
 from django.urls import reverse
 
 from . import JuntagricoTestCase
+from ..entity.member import SubscriptionMembership
 from ..entity.membership import Membership
 from ..entity.share import Share
 from ..entity.subs import SubscriptionPart
@@ -223,3 +224,54 @@ class CumulativeShareTests(ShareTests):
 @override_settings(MEMBERSHIP={'cumulative_shares': True})
 class CumulativeShareCancelTests(ShareCancelTests):
     pass
+
+
+class ShareCountTests(ShareTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        Share.objects.create(member=cls.member)
+        Share.objects.create(member=cls.member2)
+        Share.objects.create(member=cls.member3)
+        Share.objects.create(member=cls.member4)
+        for _ in range(3):
+            Share.objects.create(member=cls.member5)
+        SubscriptionMembership.objects.create(
+            member=cls.member5, subscription=cls.sub
+        )
+        cls.sub_type3.shares = 3
+        cls.sub_type3.save()
+        cls.create_membership(cls.member)
+        cls.create_membership(cls.member2)
+        cls.create_membership(cls.member4)
+
+    def testMemberRequiredSharesForSubscription(self):
+        # in shared active sub
+        self.assertEqual(self.member.required_shares_count, 0)
+        # in waiting sub
+        self.assertEqual(self.member2.required_shares_count, 2)
+        # in inactive sub and new shared sub
+        self.assertEqual(self.member3.required_shares_count, 0)
+        # without sub
+        self.assertEqual(self.member4.required_shares_count, 0)
+        # not yet joined future sub
+        self.assertEqual(self.member5.required_shares_count, 0)
+        
+    def testSubscriptionRequiredShares(self):
+        self.assertEqual(self.sub.required_shares, 1)
+        self.assertEqual(self.sub2.required_shares, 2)
+        # inactive parts don't required shares
+        self.assertEqual(self.sub3.required_shares, 0)
+
+    def testSubscriptionShareOverflow(self):
+        self.assertEqual(self.sub.share_overflow, 2)
+        self.assertEqual(self.sub2.share_overflow, -1)
+        self.assertEqual(self.sub3.share_overflow, 1)
+
+
+@override_settings(MEMBERSHIP={'cumulative_shares': True})
+class CumulativeShareCountTests(ShareCountTests):
+    def testSubscriptionShareOverflow(self):
+        self.assertEqual(self.sub.share_overflow, 1)
+        self.assertEqual(self.sub2.share_overflow, -2)
+        self.assertEqual(self.sub3.share_overflow, 1)

--- a/juntagrico/tests/test_shares.py
+++ b/juntagrico/tests/test_shares.py
@@ -3,7 +3,7 @@ import datetime
 from django.core.exceptions import ValidationError
 from django.template import Template, Context
 from django.core import mail
-from django.test import tag
+from django.test import tag, override_settings
 from django.urls import reverse
 
 from . import JuntagricoTestCase
@@ -213,3 +213,13 @@ class ShareCancelTests(ShareTestCase):
         )
         self.member.refresh_from_db()
         self.assertEqual(before, self.member.usable_shares.count())
+
+
+@override_settings(MEMBERSHIP={'cumulative_shares': True})
+class CumulativeShareTests(ShareTests):
+    pass
+
+
+@override_settings(MEMBERSHIP={'cumulative_shares': True})
+class CumulativeShareCancelTests(ShareCancelTests):
+    pass

--- a/juntagrico/util/sessions.py
+++ b/juntagrico/util/sessions.py
@@ -130,8 +130,12 @@ class SignupManager(SessionManager):
 
     def required_shares(self):
         required = self.required_shares_details()
+        if Config.cumulative_shares_for_membership():
+            total = max(required['for_membership'] + required['for_subscription'], required['for_signup'])
+        else:
+            total = max(required.values())
         return {
-            'total': max(required.values()),
+            'total': total,
             'for_primary': max(required['for_membership'], required['for_signup']),
         }
 

--- a/juntagrico/views/membership.py
+++ b/juntagrico/views/membership.py
@@ -12,7 +12,7 @@ def create(request):
     if Config.enable_shares():
         form_class = CreateMembershipWithSharesForm.create(
             Config.membership('required_shares'),
-            account.usable_shares.count()
+            account.usable_shares_for_membership_count
         )
     else:
         form_class = CreateMembershipForm

--- a/juntagrico/views_subscription.py
+++ b/juntagrico/views_subscription.py
@@ -324,11 +324,16 @@ def manage_shares(request):
     current_year = datetime.date.today().year
     if active_share_years and current_year in active_share_years:
         active_share_years.remove(current_year)
+
+    total_required = member.required_shares_count
+    required_for_membership = Config.membership('required_shares') if is_member else 0
+    if Config.cumulative_shares_for_membership():
+        total_required += required_for_membership
     renderdict = {
         'shares': shares.all(),
         'shareerror': shareerror,
-        'required_for_membership': Config.membership('required_shares') if is_member else 0,
-        'required_for_subscription': member.required_shares_count,
+        'required_for_membership': required_for_membership,
+        'required_for_subscription': total_required,
         'ibanempty': not member.iban,
         'next_membership_end_date': next_membership_end_date(),
         'certificate_years': active_share_years,

--- a/juntagrico/views_subscription.py
+++ b/juntagrico/views_subscription.py
@@ -264,7 +264,11 @@ def cancel_subscription(request, subscription_id, form_class=CancellationForm):
 def leave_subscription(request, subscription_id, form_class=LeaveForm):
     member = request.user.member
     subscription_membership = member.subscriptionmembership_set.get(subscription_id=subscription_id)
-    share_error = Config.enable_shares() and subscription_membership.subscription.share_overflow - member.usable_shares_count < 0
+    share_error = Config.enable_shares() and (
+        subscription_membership.subscription.share_overflow
+        - member.usable_shares_for_sub_count
+        < 0
+    )
     is_primary = subscription_membership.subscription.primary_member.id == member.id
     if share_error or is_primary:
         return redirect('subscription-single', subscription_id=subscription_id)

--- a/juntagrico_legacy/views.py
+++ b/juntagrico_legacy/views.py
@@ -249,7 +249,7 @@ def subscription(request, subscription_id=None):
         cancellation_date = subscription.cancellation_date
         if cancellation_date is not None and cancellation_date <= temporal.next_cancelation_date():
             end_date = temporal.end_of_business_year()
-        asc = member.usable_shares_count
+        asc = member.usable_shares_for_sub_count
         share_error = subscription.share_overflow - asc < 0
         primary = subscription.primary_member.id == member.id
         can_leave = member.active_shares_count > 0 and not share_error and not primary


### PR DESCRIPTION
# Description
Implements the second part of #623

# TODO
- [x] write tests

# Release Notes
New setting MEMBERSHIP = {'cumulative_shares': True}. If set to True the same share can not be used for the membership and for subscriptions. Default: False.
