### PR TITLE
fix: permission for exporting payout file #882

### DIFF
--- a/docs/reference/permissions.rst
+++ b/docs/reference/permissions.rst
@@ -428,7 +428,6 @@ juntagrico.is_operations_group
 .. warning::
     Deprecated. This permission will be replaced by more granular permissions in the next releases.
 
-- Download payment file for shares
 - (De)activate subscriptions
 
 Search Hints:

--- a/juntagrico/tests/test_iso20022.py
+++ b/juntagrico/tests/test_iso20022.py
@@ -18,5 +18,14 @@ class ISO2002Tests(JuntagricoTestCase):
     def testSharePAIN001(self):
         self.assertPost(reverse('share-pain001'), data={'share_ids': str(self.member.share_set.first().pk)})
 
+    def testSharePAIN001302(self):
+        # member2 has no access
+        self.assertPost(
+            reverse('share-pain001'),
+            data={'share_ids': str(self.member.share_set.first().pk)},
+            code=302,
+            member=self.member2,
+        )
+
     def testSharePAIN001404(self):
         self.assertGet(reverse('share-pain001'), code=404)

--- a/juntagrico/views_iso20022.py
+++ b/juntagrico/views_iso20022.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404
 from django.template import loader
@@ -6,9 +5,10 @@ from django.utils import timezone
 
 from juntagrico.config import Config
 from juntagrico.entity.share import Share
+from juntagrico.view_decorators import any_permission_required
 
 
-@permission_required('juntagrico.is_operations_group')
+@any_permission_required('juntagrico.view_share', 'juntagrico.change_share')
 def share_pain001(request):
     if request.method != 'POST':
         raise Http404


### PR DESCRIPTION
# Description
Fixes #882 

# Release Notes
Permission `juntagrico.is_operations_group` is no longer needed to export payout file of shares. `view_share` or `change_share` is sufficient.
