### PR TITLE
keep depot lists internal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ static/medias/photologue/temp
 testsettings2.py
 venv/*
 _build
+build
+internal_files

--- a/juntagrico/apps.py
+++ b/juntagrico/apps.py
@@ -14,7 +14,7 @@ class JuntagricoAppconfig(AppConfig):
         from .models import Subscription, Job, Share, Member, SubscriptionMembership
         from .lifecycle.submembership import add_subscription_member_to_activity_area
         from .management.commands import generate_depot_list
-        from .management import inject_rename_permissions
+        from .management import inject_rename_permissions, move_internal_files
 
         models.signals.pre_migrate.connect(inject_rename_permissions, sender=self)
         signals.depot_changed.connect(signals.on_depot_changed, sender=Subscription)
@@ -25,6 +25,7 @@ class JuntagricoAppconfig(AppConfig):
         signals.share_canceled.connect(signals.on_share_canceled, sender=Share)
         models.signals.post_save.connect(add_subscription_member_to_activity_area, sender=SubscriptionMembership)
         signals.called.connect(signals.on_depot_list_generated, sender=generate_depot_list.Command)
+        models.signals.post_migrate.connect(move_internal_files, sender=self)
         # See models.py for older signal connections
 
         '''monkey patch User email method for password reset'''

--- a/juntagrico/management/__init__.py
+++ b/juntagrico/management/__init__.py
@@ -2,8 +2,11 @@
 from typing import TYPE_CHECKING, Any
 
 from django.apps import apps as global_apps
+from django.core.files.storage import default_storage
 from django.db import DEFAULT_DB_ALIAS, migrations, router
 
+from juntagrico.config import Config
+from juntagrico.util.pdf import internal_storage
 
 if TYPE_CHECKING:
     from django.apps.registry import Apps
@@ -117,3 +120,16 @@ def inject_rename_permissions(
                 inserts.append((index + 1, operation))
         for inserted, (index, operation) in enumerate(inserts):
             migration.operations.insert(inserted + index, operation)  # type: ignore[attr-defined]
+
+
+def move_internal_files(**kwargs: Any) -> None:
+    """
+    migrate existing depot lists from default storage to internal storage
+    """
+    for depot_list in Config.depot_lists():
+        file_name = depot_list['name'] + '.pdf'
+        if default_storage.exists(file_name):
+            if not internal_storage.exists(file_name):
+                # move it only if it doesn't exist yet
+                internal_storage.save(file_name, default_storage.open(file_name))
+            default_storage.delete(file_name)

--- a/juntagrico/tests/test_lists.py
+++ b/juntagrico/tests/test_lists.py
@@ -1,7 +1,7 @@
 from io import StringIO
 
 from django.core import mail
-from django.core.files.storage import default_storage
+from django.core.files.base import ContentFile
 from django.template.loader import get_template
 from django.test import override_settings
 from django.urls import reverse
@@ -13,11 +13,20 @@ from ..util.depot_list import depot_list_data, default_depot_list_generation
 from . import JuntagricoTestCase
 
 
-@override_settings(STORAGES={
-    'default': {'BACKEND': 'django.core.files.storage.InMemoryStorage'},
-    'staticfiles': {'BACKEND': 'django.core.files.storage.FileSystemStorage'},
-})
-class DepotlistGenerationTests(JuntagricoTestCase):
+@override_settings(
+    STORAGES={
+        'internal': {'BACKEND': 'django.core.files.storage.InMemoryStorage'},
+        'staticfiles': {'BACKEND': 'django.core.files.storage.FileSystemStorage'},
+    }
+)
+class DepotlistTestCase(JuntagricoTestCase):
+    def setUp(self):
+        super().setUp()
+        from ..util.pdf import internal_storage
+        self.internal_storage = internal_storage
+
+
+class DepotlistGenerationTests(DepotlistTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -27,15 +36,16 @@ class DepotlistGenerationTests(JuntagricoTestCase):
         cls.sub4 = cls.create_sub_now(cls.depot, future_depot=cls.depot2)
         cls.member4.join_subscription(cls.sub4, True)
 
-    def tearDown(self):
-        default_storage.delete('depotlist.pdf')
-        default_storage.delete('depot_overview.pdf')
-        default_storage.delete('amount_overview.pdf')
+    def setUp(self):
+        super().setUp()
+        self.internal_storage.delete('depotlist.pdf')
+        self.internal_storage.delete('depot_overview.pdf')
+        self.internal_storage.delete('amount_overview.pdf')
 
     def assertListsCreated(self):
-        self.assertTrue(default_storage.exists('depotlist.pdf'))
-        self.assertTrue(default_storage.exists('depot_overview.pdf'))
-        self.assertTrue(default_storage.exists('amount_overview.pdf'))
+        self.assertTrue(self.internal_storage.exists('depotlist.pdf'))
+        self.assertTrue(self.internal_storage.exists('depot_overview.pdf'))
+        self.assertTrue(self.internal_storage.exists('amount_overview.pdf'))
         self.assertEqual(mail.outbox[0].subject, 'Juntagrico - Neue Depot-Liste generiert')  # admin notification email
 
     def testDepotListData(self):
@@ -107,7 +117,7 @@ class DepotlistGenerationTests(JuntagricoTestCase):
         # member has no access
         self.assertGet(url, 200)  # can see lists only
         self.assertPost(url, data, 200)
-        self.assertFalse(default_storage.exists('depotlist.pdf'))
+        self.assertFalse(self.internal_storage.exists('depotlist.pdf'))
         # admin has access
         self.assertGet(url, 200, self.admin)
         self.assertPost(url, data, 302, self.admin)
@@ -156,12 +166,8 @@ class DepotListConfigTest(JuntagricoTestCase):
 
 @override_settings(
     DEPOT_LISTS={'amount_overview': 'exports/amount_overview.html'},
-    STORAGES={
-        'default': {'BACKEND': 'django.core.files.storage.InMemoryStorage'},
-        'staticfiles': {'BACKEND': 'django.core.files.storage.FileSystemStorage'},
-    }
 )
-class AmountOverviewWithMultipleTourDaysTests(JuntagricoTestCase):
+class AmountOverviewWithMultipleTourDaysTests(DepotlistTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -171,10 +177,22 @@ class AmountOverviewWithMultipleTourDaysTests(JuntagricoTestCase):
 
     def testMultipleTourDays(self):
         default_depot_list_generation(depot_list_data())
-        self.assertTrue(default_storage.exists('amount_overview.pdf'))
+        self.assertTrue(self.internal_storage.exists('amount_overview.pdf'))
 
 
-class DepotListTests(JuntagricoTestCase):
+class DepotListTests(DepotlistTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.load_members()
+        cls.default_member = cls.member
+
+    def setUp(self):
+        super().setUp()
+        file = ContentFile('test')
+        self.internal_storage.save('depotlist.pdf', file)
+        self.internal_storage.save('depot_overview.pdf', file)
+        self.internal_storage.save('amount_overview.pdf', file)
+
     def testViewDepotList(self):
         url = reverse('lists')
         self.assertGet(url)

--- a/juntagrico/util/pdf.py
+++ b/juntagrico/util/pdf.py
@@ -1,16 +1,28 @@
 from io import BytesIO
 
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
+from django.core.files.storage import FileSystemStorage, storages, InvalidStorageError
 from django.http import HttpResponse, HttpResponseServerError, Http404
 from django.template.loader import get_template
+from django.utils.functional import LazyObject
 from xhtml2pdf import pisa
+
+
+class InternalStorage(LazyObject):
+    def _setup(self):
+        try:
+            self._wrapped = storages['internal']
+        except InvalidStorageError:
+            self._wrapped = FileSystemStorage(location='internal_files')
+
+
+internal_storage = InternalStorage()
 
 
 def render_to_pdf_http(template_name, renderdict, filename):
     '''
     Take a string of rendered html and pack it
-    into a pdfand return it thtough http
+    into a pdf and return it through http
     '''
     rendered_html = get_template(template_name).render(renderdict)
 
@@ -25,9 +37,9 @@ def render_to_pdf_http(template_name, renderdict, filename):
 
 
 def return_pdf_http(filename):
-    if not default_storage.exists(filename):
+    if not internal_storage.exists(filename):
         raise Http404
-    with default_storage.open(filename) as pdf_file:
+    with internal_storage.open(filename) as pdf_file:
         content = pdf_file.read()
     content_disposition = "attachment; filename=" + filename
     response = HttpResponse(content, content_type='application/pdf')
@@ -39,9 +51,9 @@ def render_to_pdf_storage(template_name, context, filename):
     '''
     Take a string of rendered html and pack it into a pdf and save it
     '''
-    if default_storage.exists(filename):
-        default_storage.delete(filename)
+    if internal_storage.exists(filename):
+        internal_storage.delete(filename)
     rendered_html = get_template(template_name).render(context)
     pdf = BytesIO()
     pisa.CreatePDF(BytesIO(str(rendered_html).encode('utf-8')), dest=pdf)
-    default_storage.save(filename, ContentFile(pdf.getvalue()))
+    internal_storage.save(filename, ContentFile(pdf.getvalue()))

--- a/juntagrico/views_admin.py
+++ b/juntagrico/views_admin.py
@@ -2,7 +2,6 @@ import datetime
 
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required, login_required, user_passes_test
-from django.core.files.storage import default_storage
 from django.core.management import call_command
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
@@ -17,7 +16,7 @@ from juntagrico.entity.subs import Subscription
 from juntagrico.entity.subtypes import SubscriptionBundle
 from juntagrico.forms import GenerateListForm, ShiftTimeForm
 from juntagrico.util import return_to_previous_location, addons
-from juntagrico.util.pdf import return_pdf_http
+from juntagrico.util.pdf import return_pdf_http, internal_storage
 from juntagrico.view_decorators import any_permission_required
 from juntagrico.views_subscription import error_page
 
@@ -81,11 +80,11 @@ def manage_list(request, extra_lists=None):
         )
         for depot_list in list(Config.depot_lists(default_names)) + extra_lists:
             file_name = depot_list['file_name'] + '.pdf'
-            exists = default_storage.exists(file_name)
+            exists = internal_storage.exists(file_name)
             creation_time = None
             if exists:
                 try:
-                    creation_time = default_storage.get_created_time(file_name)
+                    creation_time = internal_storage.get_created_time(file_name)
                 except NotImplementedError:
                     pass
             depot_lists.append({

--- a/settings/deployment.py
+++ b/settings/deployment.py
@@ -1,10 +1,13 @@
 # these settings tests if collectstatic will work during deployment
-from .dev import *  # noqa: F401
+from .dev import *  # noqa: F403
 
 DEBUG = False
 ALLOWED_HOSTS = ['localhost']
 
 STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
     },


### PR DESCRIPTION
# Description
The default storage, used for depot lists, defaults to `MEDIA_ROOT` which is intended for public files. In a typical django deployment those files are served to the public.
Depot lists should not be public, thus they should be stored in a different location.

Existing depot lists will automatically be moved to the new location when applying migrations.

# Release Notes
After upgrading and applying migrations, check if any sensible files remain in your media folder on the server and delete them accordingly.
