### PR TITLE
admin: return to previous page after change on admin site

### DIFF
--- a/juntagrico/admins/__init__.py
+++ b/juntagrico/admins/__init__.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 from django.contrib.admin.options import BaseModelAdmin, InlineModelAdmin
 from django.db.models import TextField
+from django.http import HttpResponseRedirect, HttpRequest, HttpResponse
+from django.urls import resolve, Resolver404
 from djrichtextfield.widgets import RichTextWidget
 from import_export.admin import ExportMixin
 
@@ -15,6 +17,35 @@ class BaseAdmin(admin.ModelAdmin):
         self.inlines = self.inlines or []
         self.inlines.extend(addons.config.get_model_inlines(model))
         super().__init__(model, admin_site)
+
+    def _response_post_save(self, request, obj):
+        # redirect to previous page if defined
+        if next_page := request.GET.get('next'):
+            try:
+                resolve(next_page)
+                return HttpResponseRedirect(next_page)
+            except Resolver404:
+                pass
+        return super()._response_post_save(request, obj)
+
+    def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
+        # hide delete button in change view if we want to redirect to previous page as it would not carry the information.
+        if 'next' in request.GET:
+            context.update({
+                'show_delete': False,
+            })
+        return super().render_change_form(request, context, add, change, form_url, obj)
+
+    def response_delete(self, request: HttpRequest, obj_display: str, obj_id: int) -> HttpResponse:
+        # redirect to previous page if defined
+        response = super().response_delete(request, obj_display, obj_id)
+        if next_page := request.GET.get('next'):
+            try:
+                resolve(next_page)
+                return HttpResponseRedirect(next_page)
+            except Resolver404:
+                pass
+        return response
 
 
 class RichTextAdmin(BaseAdmin):

--- a/juntagrico/admins/forms/job_copy_form.py
+++ b/juntagrico/admins/forms/job_copy_form.py
@@ -118,7 +118,7 @@ class JobMassCopyForm(forms.ModelForm):
             if commit:
                 new_job.save()
             self.new_jobs.append(new_job)
-        return self.new_jobs[0] if self.new_jobs else None
+        return self.instance
 
     def save_related(self, formsets):
         # save and apply contacts

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -141,7 +141,7 @@ class JobCopy(admin.ModelAdmin):
 
     def response_change(self, request, obj):
         if self.is_mass_copy_view(request):
-            # show one of the new jobs on page
+            # show the original job page
             return HttpResponseRedirect(reverse('job', args=[obj.id]))
         return super().response_change(request, obj)
 

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -1,7 +1,8 @@
-from datetime import timedelta, datetime, date
+import datetime
 
+from django.template.defaultfilters import date
 from django.urls import path, reverse
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.http import HttpResponseRedirect
 from django.utils import timezone
 from django.utils.safestring import mark_safe
@@ -121,6 +122,14 @@ class JobCopy(admin.ModelAdmin):
     def save_related(self, request, form, formsets, change):
         if self.is_mass_copy_view(request):
             form.save_related(formsets)
+            for job in form.new_jobs:
+                job_url = reverse('job', args=[job.pk])
+                messages.success(request, mark_safe(
+                    _('Einsatz erstellt: {job} am {time}').format(
+                        job=f'<a href="{job_url}">{job.type.get_name}</a>',
+                        time=date(job.time, 'SHORT_DATETIME_FORMAT'),
+                    )
+                ))
         else:
             super().save_related(request, form, formsets, change)
 
@@ -129,6 +138,12 @@ class JobCopy(admin.ModelAdmin):
             # show new job on page
             return HttpResponseRedirect(reverse('job', args=[obj.id]))
         return super().response_add(request, obj, post_url_continue)
+
+    def response_change(self, request, obj):
+        if self.is_mass_copy_view(request):
+            # show one of the new jobs on page
+            return HttpResponseRedirect(reverse('job', args=[obj.id]))
+        return super().response_change(request, obj)
 
 
 class JobAdmin(PolymorphicInlineSupportMixin, JobCopy, OnlyFutureJobMixin, AreaCoordinatorMixin, RichTextAdmin):
@@ -172,7 +187,7 @@ class JobAdmin(PolymorphicInlineSupportMixin, JobCopy, OnlyFutureJobMixin, AreaC
             time = instance.time
             if not request.user.has_perm('juntagrico.can_edit_past_jobs') and time <= timezone.now():
                 # create copy in future if job is in past and member can't edit past jobs
-                time = datetime.combine(date.today() + timedelta(7), time.time())
+                time = datetime.datetime.combine(datetime.date.today() + datetime.timedelta(7), time.time())
             new_job = RecuringJob(type=instance.type, slots=instance.slots, time=time)
             new_job.save()
 

--- a/juntagrico/admins/job_admin.py
+++ b/juntagrico/admins/job_admin.py
@@ -119,6 +119,11 @@ class JobCopy(admin.ModelAdmin):
             return [ContactInlineForJob]
         return super().get_inlines(request, obj)
 
+    def save_model(self, request, obj, form, change):
+        # don't save original object on mass copy
+        if not self.is_mass_copy_view(request):
+            super().save_model(request, obj, form, change)
+
     def save_related(self, request, form, formsets, change):
         if self.is_mass_copy_view(request):
             form.save_related(formsets)

--- a/juntagrico/templates/job.html
+++ b/juntagrico/templates/job.html
@@ -36,7 +36,7 @@
             <div class="row pb-4">
                 <div class="col-12">
                     {% if edit_url.strip %}
-                        <a href="{{ edit_url }}" class="btn btn-primary">
+                        <a href="{{ edit_url }}?next={{ request.path|urlencode }}" class="btn btn-primary">
                             <i class="bi bi-pencil-square mr-1"></i>
                             {% trans "Einsatz bearbeiten" %}
                         </a>

--- a/juntagrico/templates/juntagrico/config/snippets/bundles.html
+++ b/juntagrico/templates/juntagrico/config/snippets/bundles.html
@@ -12,8 +12,13 @@
                 <div class="card-header">
                     <strong>{{ bundle }}</strong>
                     {% if perms.juntagrico.change_subscriptionbundle %}
-                        <a href="{% url 'admin:juntagrico_subscriptionbundle_change' bundle.id %}">
+                        <a href="{% url 'admin:juntagrico_subscriptionbundle_change' bundle.id %}?next={{ request.path|urlencode }}">
                             <i class="bi bi-pencil-square"></i>
+                        </a>
+                    {% endif %}
+                    {% if perms.juntagrico.delete_subscriptionbundle %}
+                        <a href="{% url 'admin:juntagrico_subscriptionbundle_delete' bundle.id %}?next={{ request.path|urlencode }}">
+                            <i class="bi bi-trash"></i>
                         </a>
                     {% endif %}
                 </div>
@@ -52,7 +57,7 @@
             </div>
         {% endfor %}
         {% if perms.juntagrico.add_subscriptionproduct %}
-            <a class="btn btn-primary" href="{% url 'admin:juntagrico_subscriptionbundle_add' %}">
+            <a class="btn btn-primary" href="{% url 'admin:juntagrico_subscriptionbundle_add' %}?next={{ request.path|urlencode }}">
                 <i class="bi bi-plus mr-1"></i>
                 Pakete & Typen hinzufügen
             </a>

--- a/juntagrico/templates/juntagrico/config/snippets/categories.html
+++ b/juntagrico/templates/juntagrico/config/snippets/categories.html
@@ -12,8 +12,13 @@
                 <div class="card-header">
                     <strong>{{ category }}</strong>
                     {% if perms.juntagrico.change_subscriptioncategory %}
-                        <a href="{% url 'admin:juntagrico_subscriptioncategory_change' category.id %}">
+                        <a href="{% url 'admin:juntagrico_subscriptioncategory_change' category.id %}?next={{ request.path|urlencode }}">
                             <i class="bi bi-pencil-square"></i>
+                        </a>
+                    {% endif %}
+                    {% if perms.juntagrico.delete_subscriptioncategory %}
+                        <a href="{% url 'admin:juntagrico_subscriptioncategory_delete' category.id %}?next={{ request.path|urlencode }}">
+                            <i class="bi bi-trash"></i>
                         </a>
                     {% endif %}
                 </div>
@@ -29,7 +34,7 @@
     {% endfor %}
     {% if perms.juntagrico.add_subscriptioncategory %}
         <div class="col mb-3">
-            <a class="btn btn-primary" href="{% url 'admin:juntagrico_subscriptioncategory_add' %}">
+            <a class="btn btn-primary" href="{% url 'admin:juntagrico_subscriptioncategory_add' %}?next={{ request.path|urlencode }}">
                 <i class="bi bi-plus mr-1"></i>
                 {% trans "Kategorie hinzufügen" %}
             </a>

--- a/juntagrico/templates/juntagrico/config/snippets/products.html
+++ b/juntagrico/templates/juntagrico/config/snippets/products.html
@@ -12,8 +12,13 @@
                 <div class="card-header">
                     <strong>{{ product }}</strong>
                     {% if perms.juntagrico.change_subscriptionproduct %}
-                        <a href="{% url 'admin:juntagrico_subscriptionproduct_change' product.id %}">
+                        <a href="{% url 'admin:juntagrico_subscriptionproduct_change' product.id %}?next={{ request.path|urlencode }}">
                             <i class="bi bi-pencil-square"></i>
+                        </a>
+                    {% endif %}
+                    {% if perms.juntagrico.delete_subscriptionproduct %}
+                        <a href="{% url 'admin:juntagrico_subscriptionproduct_delete' product.id %}?next={{ request.path|urlencode }}">
+                            <i class="bi bi-trash"></i>
                         </a>
                     {% endif %}
                 </div>
@@ -46,7 +51,7 @@
     {% endfor %}
     {% if perms.juntagrico.add_subscriptionproduct %}
         <div class="col mb-3">
-            <a class="btn btn-primary" href="{% url 'admin:juntagrico_subscriptionproduct_add' %}">
+            <a class="btn btn-primary" href="{% url 'admin:juntagrico_subscriptionproduct_add' %}?next={{ request.path|urlencode }}">
                 <i class="bi bi-plus mr-1"></i>
                 {% trans "Produkt hinzufügen" %}
             </a>

--- a/juntagrico/templates/juntagrico/manage/assignments.html
+++ b/juntagrico/templates/juntagrico/manage/assignments.html
@@ -65,7 +65,7 @@
                         {{ subscription.activation_date|date:"Y-m-d" }}
                     </td>
                     <td>
-                        <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}">
+                        <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}?next={{ request.path|urlencode }}">
                             {{ subscription.state_text }}
                         </a>
                         {% if subscription.canceled %}

--- a/juntagrico/templates/juntagrico/manage/member/snippets/display_linked.html
+++ b/juntagrico/templates/juntagrico/manage/member/snippets/display_linked.html
@@ -1,7 +1,7 @@
 {% load juntagrico.snippets %}
 {% impersonate_start request member %}
 {% if perms.juntagrico.view_member or perms.juntagrico.change_member %}
-    <a href="{% url 'admin:juntagrico_member_change' member.id %}"
+    <a href="{% url 'admin:juntagrico_member_change' member.id %}?next={{ request.path|urlencode }}"
        {% if css_class %}class="{{ css_class }}"{% endif %}>
         {{ member }}
     </a>

--- a/juntagrico/templates/juntagrico/manage/share/canceled.html
+++ b/juntagrico/templates/juntagrico/manage/share/canceled.html
@@ -50,7 +50,7 @@
             {% for share in object_list %}
                 <tr>
                     <td>
-                        <a href="{% url 'admin:juntagrico_share_change' share.id %}">
+                        <a href="{% url 'admin:juntagrico_share_change' share.id %}?next={{ request.path|urlencode }}">
                             {{ share }}
                         </a>
                         <div class="d-none share_id{% if share.backpayable %} backpayable{% endif %}">

--- a/juntagrico/templates/juntagrico/manage/share/unpaid.html
+++ b/juntagrico/templates/juntagrico/manage/share/unpaid.html
@@ -40,7 +40,7 @@
                 {% for share in shares %}
                     <tr>
                         <td class="share_id">
-                            <a href="{% url 'admin:juntagrico_share_change' share.id %}">
+                            <a href="{% url 'admin:juntagrico_share_change' share.id %}?next={{ request.path|urlencode }}">
                                 {{ share }}
                             </a>
                         </td>

--- a/juntagrico/templates/juntagrico/manage/subscription/pending.html
+++ b/juntagrico/templates/juntagrico/manage/subscription/pending.html
@@ -66,7 +66,7 @@
                 {% with canceled_parts=subscription.parts.canceled ordered_parts=subscription.parts.ordered %}
                     <tr class="{% include "./snippets/row_class.html" %}">
                         <td>
-                            <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}">
+                            <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}?next={{ request.path|urlencode }}">
                                 {{ subscription.id }}
                             </a>
                         </td>

--- a/juntagrico/templates/juntagrico/manage/subscription/snippets/display_linked.html
+++ b/juntagrico/templates/juntagrico/manage/subscription/snippets/display_linked.html
@@ -1,5 +1,5 @@
 {% if perms.juntagrico.view_subscription or perms.juntagrico.change_subscription %}
-    <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}"
+    <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}?next={{ request.path|urlencode }}"
        {% if css_class %}class="{{ css_class }}"{% endif %}>
         {{ subscription.id }}
     </a>

--- a/juntagrico/templates/juntagrico/manage/subscription/trial.html
+++ b/juntagrico/templates/juntagrico/manage/subscription/trial.html
@@ -67,7 +67,7 @@
                 {% with remaining=trial_part.remaining_trial_days %}
                     <tr class="{% if trial_part.is_extra %}show-extra{% else %}show-normal{% endif %}">
                         <td>
-                            <a href="{% url 'admin:juntagrico_subscription_change' trial_part.subscription.id %}">
+                            <a href="{% url 'admin:juntagrico_subscription_change' trial_part.subscription.id %}?next={{ request.path|urlencode }}">
                                 {{ trial_part.type }}
                             </a>
                         </td>

--- a/juntagrico/templates/juntagrico/my/area/show.html
+++ b/juntagrico/templates/juntagrico/my/area/show.html
@@ -61,8 +61,7 @@
                 {% endfor %}
                 {% if edit_form %}
                     <div class="mt-3">
-                        {# TODO: open popup instead #}
-                        <a href="{% url 'admin:juntagrico_activityarea_change' area.id %}#juntagrico-contact-content_type-object_id-group"
+                        <a href="{% url 'admin:juntagrico_activityarea_change' area.id %}?next={{ request.path|urlencode }}#juntagrico-contact-content_type-object_id-group"
                            target="_blank"
                            id="edit_contacts" class="btn btn-outline-primary">
                             <i class="bi bi-pencil-square mr-1"></i>

--- a/juntagrico/templates/snippets/snippet_jobs.html
+++ b/juntagrico/templates/snippets/snippet_jobs.html
@@ -6,13 +6,13 @@
 
 {% block tools %}
     {% if perms.juntagrico.change_recuringjob or can_manage_jobs %}
-        <a href="{% url 'admin:juntagrico_recuringjob_add' %}" class="btn btn-primary mr-1">
+        <a href="{% url 'admin:juntagrico_recuringjob_add' %}?next={{ request.path|urlencode }}" class="btn btn-primary mr-1">
             <i class="bi bi-calendar-plus mr-1"></i>
             {% trans "Wiederkehrenden Einsatz ausschreiben" %}
         </a>
     {% endif %}
     {% if perms.juntagrico.change_onetimejob or can_manage_jobs %}
-        <a href="{% url 'admin:juntagrico_onetimejob_add' %}" class="btn btn-outline-primary">
+        <a href="{% url 'admin:juntagrico_onetimejob_add' %}?next={{ request.path|urlencode }}" class="btn btn-outline-primary">
             <i class="bi bi-plus mr-1"></i>
             {% trans "Einzel-Einsatz ausschreiben" %}
         </a>

--- a/juntagrico/tests/test_admin.py
+++ b/juntagrico/tests/test_admin.py
@@ -108,6 +108,37 @@ class AdminTests(JuntagricoTestCaseWithShares):
         }, member=self.area_admin_job_modifier, code=302)
         self.assertGreater(RecuringJob.objects.last().time, timezone.now())
 
+    def testAdminReturn(self):
+        change_url = reverse('admin:juntagrico_recuringjob_change', args=(self.job1.pk,)) + '?next=/config/'
+        self.assertGet(change_url, member=self.area_admin_job_modifier)
+        response = self.assertPost(
+            change_url,
+            data={
+                'type': self.job1.type.pk,
+                'slots': 1,
+                'multiplier': 1,
+                'time_0': self.job1.time.date(),
+                'time_1': self.job1.time.time(),
+                'assignment_set-TOTAL_FORMS': 0,
+                'assignment_set-INITIAL_FORMS': 0,
+                'juntagrico-contact-content_type-object_id-TOTAL_FORMS': 0,
+                'juntagrico-contact-content_type-object_id-INITIAL_FORMS': 0,
+            },
+            member=self.area_admin_job_modifier,
+            code=302,
+        )
+        self.assertRedirects(response, reverse('config'), fetch_redirect_response=False)
+
+    def testAdminDeleteReturn(self):
+        delete_url = reverse('admin:juntagrico_recuringjob_delete', args=(self.job1.pk,)) + '?next=/config/'
+        response = self.assertPost(
+            delete_url,
+            data={'post': 'yes'},
+            member=self.area_admin_job_modifier,
+            code=302,
+        )
+        self.assertRedirects(response, reverse('config'), fetch_redirect_response=False)
+
     def testDeliveryAdmin(self):
         self.assertGet(reverse('admin:juntagrico_delivery_add'), member=self.admin)
         url = reverse('admin:juntagrico_delivery_changelist')

--- a/juntagrico/tests/test_areas.py
+++ b/juntagrico/tests/test_areas.py
@@ -10,7 +10,9 @@ class AreaTests(JuntagricoTestCase):
         self.assertGet(reverse('areas'))
 
     def testArea(self):
-        self.assertGet(reverse('area', args=[self.area.pk]))
+        url = reverse('area', args=[self.area.pk])
+        self.assertGet(url)
+        self.assertGet(url, member=self.area_admin)
 
     def testAreaJoinAndLeave(self):
         self.assertGet(reverse('area-join', args=[self.area2.pk]))

--- a/juntagrico_legacy/templates/management_lists/canceledlist.html
+++ b/juntagrico_legacy/templates/management_lists/canceledlist.html
@@ -41,7 +41,7 @@
             {% for subscription in management_list %}
                 <tr>
                     <td>
-                        <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}">
+                        <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}?next={{ request.path|urlencode }}">
                             {{ subscription }}
                         </a>
                     </td>

--- a/juntagrico_legacy/templates/management_lists/waitinglist.html
+++ b/juntagrico_legacy/templates/management_lists/waitinglist.html
@@ -49,7 +49,7 @@
             {% for subscription in management_list %}
                 <tr>
                     <td>
-                        <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}">
+                        <a href="{% url 'admin:juntagrico_subscription_change' subscription.id %}?next={{ request.path|urlencode }}">
                             {{ subscription }}
                         </a>
                     </td>


### PR DESCRIPTION
# Description
Some links on the front page open the django admin edit page of an object directly. After saving those objects the changelist was shown as normal in the django admin.
This PR makes it redirect to the original page.

- For mass-copy of jobs, messages now indicate which new jobs have been created.
- Added delete buttons on the configuration page

# TODO
- [x] write tests
