### PR TITLE
fix: exports if no jobs are defined

### DIFF
--- a/juntagrico/admins/forms/import_export_form.py
+++ b/juntagrico/admins/forms/import_export_form.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django import forms
 from django.db.models import Max, Min
 from django.forms import SelectDateWidget
@@ -28,7 +30,11 @@ class ExportAssignmentDateRangeForm(SelectableFieldsExportForm):
         super().__init__(formats, *args, **kwargs)
         # offer meaningful year range
         jobs = Job.objects.aggregate(oldest_year=Min('time__year'), newest_year=Max('time__year'))
+        this_year = datetime.date.today().year
         # extend range to year before and after to be able to always select entire business year.
-        years = range(jobs['oldest_year'] - 1, jobs['newest_year'] + 2)
+        years = range(
+            (jobs['oldest_year'] or this_year) - 1,
+            (jobs['newest_year'] or this_year) + 2,
+        )
         self.fields['export_start_date'].widget.years = years
         self.fields['export_end_date'].widget.years = years

--- a/juntagrico/tests/test_export.py
+++ b/juntagrico/tests/test_export.py
@@ -66,3 +66,10 @@ class ExportTests(JuntagricoTestCase):
         response = self.assertPost(export_url, member=self.admin,
                                    data=self.get_data(1, selected=fields['SubscriptionPartResource']))
         self.assertEqual(response.headers['Content-Type'], 'text/csv')
+
+
+class EmptyExportTests(ExportTests):
+    @classmethod
+    def set_up_job(cls):
+        # don't create any jobs
+        pass

--- a/juntagrico/tests/test_mailer.py
+++ b/juntagrico/tests/test_mailer.py
@@ -258,38 +258,38 @@ class MailerTests(JuntagricoTestCaseWithShares):
         )
 
     def testMemberFromEmailSelection(self):
-        self.assertListEqual(self.member.all_emails(), [('private', 'email1@email.org')])
-        self.assertListEqual(self.member2.all_emails(), [
+        self.assertSetEqual(set(self.member.all_emails()), {('private', 'email1@email.org')})
+        self.assertSetEqual(set(self.member2.all_emails()), {
             ('general', 'info@juntagrico.juntagrico'), ('private', 'email2@email.org')
-        ])
-        self.assertListEqual(self.member3.all_emails(), [
+        })
+        self.assertSetEqual(set(self.member3.all_emails()), {
             ('for_members', 'member@juntagrico.juntagrico'),
             ('for_subscriptions', 'subscription@juntagrico.juntagrico'),
             ('private', 'email3@email.org')
-        ])
-        self.assertListEqual(self.member4.all_emails(), [
+        })
+        self.assertSetEqual(set(self.member4.all_emails()), {
             ('for_shares', 'share@juntagrico.juntagrico'), ('private', 'email4@email.org')
-        ])
-        self.assertListEqual(self.member5.all_emails(), [
+        })
+        self.assertSetEqual(set(self.member5.all_emails()), {
             ('technical', 'it@juntagrico.juntagrico'), ('private', 'email5@email.org')
-        ])
-        self.assertListEqual(self.area_admin.all_emails(), [
+        })
+        self.assertSetEqual(set(self.area_admin.all_emails()), {
             ('area1-m0', 'email_contact@example.org'),
             ('area2-m2', 'email2@email.org'),
             ('private', 'areaadmin@email.org')
-        ])
-        self.assertListEqual(self.area_admin_contact.all_emails(), [
+        })
+        self.assertSetEqual(set(self.area_admin_contact.all_emails()), {
             ('area1-m0', 'email_contact@example.org'),
             ('private', 'area_admin13@email.org')
-        ])
-        self.assertListEqual(self.admin.all_emails(), [
+        })
+        self.assertSetEqual(set(self.admin.all_emails()), {
             ('general', 'info@juntagrico.juntagrico'),
             ('for_members', 'member@juntagrico.juntagrico'),
             ('for_subscriptions', 'subscription@juntagrico.juntagrico'),
             ('for_shares', 'share@juntagrico.juntagrico'),
             ('technical', 'it@juntagrico.juntagrico'),
             ('private', 'admin@email.org')
-        ])
+        })
 
     def testMailSend(self):
         with open('juntagrico/tests/test_mailer.py') as fp:


### PR DESCRIPTION
# Description
If no jobs were defined the export page would fail to load the year range for the assignment count and crash.
