### PR TITLE
 admin: send only one admin notification email on part change #683

### DIFF
--- a/juntagrico/forms/__init__.py
+++ b/juntagrico/forms/__init__.py
@@ -625,8 +625,7 @@ class SubscriptionPartChangeForm(SubscriptionPartBaseForm):
 
     def send_notification(self, new_part):
         # notify admin
-        adminnotification.subpart_canceled(self.part)
-        adminnotification.subparts_created([new_part], self.part.subscription)
+        adminnotification.subpart_changed(self.part, new_part)
 
 
 class SubscriptionPartContinueForm(SubscriptionPartChangeForm):

--- a/juntagrico/lifecycle/membership.py
+++ b/juntagrico/lifecycle/membership.py
@@ -72,6 +72,12 @@ def sync(sender, instance, **kwargs):
         activation_date = active_shares.aggregate(
             paid_date=Min('paid_date'),
         )['paid_date']
+        # if member has previous membership the current one can't start before the previous ended
+        end_of_last_membership = account.memberships.aggregate(
+            deactivation_date=Max('deactivation_date'),
+        )['deactivation_date']
+        if end_of_last_membership and end_of_last_membership > activation_date:
+            activation_date = end_of_last_membership + datetime.timedelta(days=1)
         if current_membership is not None:
             # update existing membership
             current_membership.activation_date = activation_date

--- a/juntagrico/mailer/adminnotification.py
+++ b/juntagrico/mailer/adminnotification.py
@@ -2,7 +2,7 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 
 from juntagrico.config import Config
-from juntagrico.mailer import EmailBuilder
+from juntagrico.mailer import EmailBuilder, recipients_by_permission
 
 """
 Admin notification emails
@@ -88,6 +88,20 @@ def subpart_canceled(part):
         {
             'part': part,
             'subscription': part.subscription
+        },
+    ).send()
+
+
+def subpart_changed(old_part, new_part):
+    EmailBuilder(
+        recipients_by_permission('notified_on_subscriptionpart_creation')
+        | recipients_by_permission('notified_on_subscriptionpart_cancellation'),
+        _('Bestandteil geändert'),
+        'juntagrico/mails/admin/subscription/part/changed.txt',
+        {
+            'old_part': old_part,
+            'new_part': new_part,
+            'subscription': new_part.subscription,
         },
     ).send()
 

--- a/juntagrico/management/commands/mailtexts.py
+++ b/juntagrico/management/commands/mailtexts.py
@@ -99,6 +99,9 @@ class Command(BaseCommand):
                 print('*** mails/admin/subpart_canceled.txt (a_subpart_canceled) ***')
                 adminnotification.subpart_canceled(canceled_part)
 
+                print('*** admin/subscription/part/changed ***')
+                adminnotification.subpart_changed(canceled_part, future_parts[0])
+
                 print('*** mails/member/subscription/part/canceled.txt ***')
                 membernotification.part_canceled_for_you(canceled_part)
 

--- a/juntagrico/templates/juntagrico/mails/admin/subscription/part/changed.txt
+++ b/juntagrico/templates/juntagrico/mails/admin/subscription/part/changed.txt
@@ -1,0 +1,11 @@
+{% extends "juntagrico/mails/admin/subscription/base.txt" %}
+{% load i18n %}
+{% load juntagrico.config %}
+
+{% block subscription_message %}
+{% vocabulary "subscription" as v_subscription %}
+{% blocktrans %}Soeben wurde ein {{ v_subscription }}-Bestandteil geändert{% endblocktrans %}
+
+{%trans "Bisher: " %}{{ old_part }}
+{%trans "Neu: " %}{{ new_part }}
+{% endblock %}

--- a/juntagrico/tests/test_subs.py
+++ b/juntagrico/tests/test_subs.py
@@ -109,7 +109,7 @@ class SubscriptionTests(JuntagricoTestCaseWithShares):
         part.refresh_from_db()
         self.assertTrue(part.canceled, 'part should be canceled')
         # check notification was sent to admins
-        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(len(mail.outbox), 1)
 
         # change waiting part
         part = self.sub.parts.filter(activation_date=None).first()

--- a/juntagrico/tests/test_trial_subs.py
+++ b/juntagrico/tests/test_trial_subs.py
@@ -52,7 +52,7 @@ class TrialSubscriptionTests(TrialSubscriptionTestCase):
         self.assertEqual(self.trial_part1.type, self.trial_sub_type)
         self.assertTrue(self.trial_part1.canceled)
         # check notification was sent to admins
-        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(len(mail.outbox), 1)
 
     def testContinueTrialBeforeActivation(self):
         mail.outbox.clear()


### PR DESCRIPTION
# Description
Implements #683, but uses the existing permissions. Those who have the notify on create and/or cancel permission will get this notification

# TODO
- [x] write tests

