### PR TITLE
fix: sanitize recipient names for emails

### DIFF
--- a/juntagrico/queryset/member.py
+++ b/juntagrico/queryset/member.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 from django.db.models import QuerySet, Sum, Case, When, Prefetch, F, Q, Count, Exists, OuterRef
 from django.utils.decorators import method_decorator
@@ -126,4 +127,5 @@ class MemberQuerySet(SubscriptionMembershipQuerySetMixin, QuerySet):
             .annotate_core_assignment_count(start, end, prefix, **extra_filters)
 
     def as_email_recipients(self):
-        return [f'{m} <{m.email}>' for m in self]
+        allowed = re.compile(r"[^\w \-._']", flags=re.UNICODE)
+        return [f'{allowed.sub("", str(m))} <{m.email}>' for m in self]

--- a/juntagrico/tests/test_mailer.py
+++ b/juntagrico/tests/test_mailer.py
@@ -292,6 +292,8 @@ class MailerTests(JuntagricoTestCaseWithShares):
         })
 
     def testMailSend(self):
+        self.member.last_name += '="ö<>é,@'  # add some forbidden characters (and some allowed non-trivial ones)
+        self.member.save()
         with open('juntagrico/tests/test_mailer.py') as fp:
             post_data = {
                 'from_email': 'private',
@@ -310,7 +312,7 @@ class MailerTests(JuntagricoTestCaseWithShares):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].attachments[0][0], 'test_mailer.py')
         expected = [
-            'first_name1 last_name1 <email1@email.org>',
+            'first_name1 last_name1öé <email1@email.org>',
             'first_name3 last_name3 <email3@email.org>',
             'first_name6 last_name6 <member6@email.org>',
             'first_name7 last_name7 <member7@email.org>',


### PR DESCRIPTION
# Description
Members with commas or some other special characters in the name would cause a crash when sending an email to them using the email form. Because the recipient is rendered as `firstname lastname <email-address>`.
This PR fixes that by stripping all problematic characters from the name for the recipient list.

# TODO
- [x] write tests
