### PR TITLE
customize: make price display customizable #892

### DIFF
--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -169,6 +169,21 @@ Defines the structure to display subscription bundles in the subscription/part o
 
 Has the same blocks as ``category_container.html``.
 
+juntagrico/snippets/subscription/type.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Displays subscription type in any order process and in configuration view.
+
+- ``price``: price display for all cases
+- ``periodic_price``: price display for types that have periods
+- ``price_display``: price display for types without periods
+
+
+juntagrico/snippets/subscription/type_duration_info.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Displays the runtime of the subscription type.
+
 
 juntagrico/subscription/create/form/no_subscription_field.html
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -209,6 +224,18 @@ Each section has a block:
 - ``activity_areas``
 - ``shares``
 - ``comment``
+
+
+juntagrico/subscription/create/summary/snippets/part.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Displays selected subscription part types in signup summary.
+
+- ``price``: price display for all cases
+- ``periodic_price``: price display for types that have periods
+- ``trial_price``: price display for trial types without periods
+- ``regular_price``: price display for non-trial types without periods
+
 
 Subscription Templates
 ----------------------

--- a/juntagrico/entity/subtypes.py
+++ b/juntagrico/entity/subtypes.py
@@ -5,7 +5,6 @@ from django.utils.translation import gettext_lazy as _, gettext
 from juntagrico.config import Config
 from juntagrico.entity import JuntagricoBaseModel
 from juntagrico.queryset.subtypes import SubscriptionTypeQueryset, ProductSizeQueryset, SubscriptionProductQueryset
-from juntagrico.util import temporal
 
 
 class SubscriptionProduct(JuntagricoBaseModel):
@@ -143,14 +142,6 @@ class SubscriptionType(JuntagricoBaseModel):
     @property
     def has_periods(self):
         return self.periods.count() > 0
-
-    def min_duration_info(self):
-        if self.trial_days:
-            return gettext('Für {num} Tage. Keine automatische Verlängerung.').format(num=self.trial_days)
-        if self.has_periods:
-            return None  # price list already shows end of periods
-        date = temporal.end_of_business_year()
-        return gettext('Bis {day}.{month}. Automatische Verlängerung.').format(day=date.day, month=date.month)
 
     @property
     def display_name(self):

--- a/juntagrico/templates/juntagrico/snippets/subscription/type.html
+++ b/juntagrico/templates/juntagrico/snippets/subscription/type.html
@@ -1,3 +1,4 @@
+{% load juntagrico.snippets %}
 {% load juntagrico.common %}
 {% load i18n %}
 {% load juntagrico.config %}
@@ -16,21 +17,25 @@
 
     {% block price %}
         {% if type.has_periods %}
-            {% for period in type.periods.all %}
-                <div>
-                    <strong>{{ period.price|price }}</strong>
-                    {{ period.start_day }}.{{ period.start_month }}. - {{ period.end_day }}.{{ period.end_month }}
-                </div>
-            {% endfor %}
+            {% block periodic_price %}
+                {% for period in type.periods.all %}
+                    <div>
+                        <strong>{{ period.price|price }}</strong>
+                        {{ period.start_day }}.{{ period.start_month }}. - {{ period.end_day }}.{{ period.end_month }}
+                    </div>
+                {% endfor %}
+            {% endblock %}
             {% include "juntagrico/snippets/subscription/depot_fee.html" %}
         {% else %}
             <div class="type-details type-price">
-                <strong>{{ type.price|price }}</strong>
-                {% if type.trial_days %}
-                    {% blocktrans with days=type.trial_days %}für {{ days }} Tage{% endblocktrans %}
-                {% else %}
-                    {% trans "pro Jahr" %}
-                {% endif %}
+                {% block price_display %}
+                    <strong>{{ type.price|price }}</strong>
+                    {% if type.trial_days %}
+                        {% blocktrans with days=type.trial_days %}für {{ days }} Tage{% endblocktrans %}
+                    {% else %}
+                        {% trans "pro Jahr" %}
+                    {% endif %}
+                {% endblock %}
                 {% include "juntagrico/snippets/subscription/depot_fee.html" %}
             </div>
         {% endif %}
@@ -94,7 +99,7 @@
     {% block duration %}
         {% if not type.has_periods %}
             <div class="type-duration mt-3">
-                {% trans "Laufzeit" %}: {{ type.min_duration_info }}
+                {% trans "Laufzeit" %}: {% type_duration_info type %}
             </div>
         {% endif %}
     {% endblock %}

--- a/juntagrico/templates/juntagrico/snippets/subscription/type_duration_info.html
+++ b/juntagrico/templates/juntagrico/snippets/subscription/type_duration_info.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+{% if subscription.trial_days %}
+    {% blocktrans trimmed with num=subscription.trial_days %}
+        Für {{ num }} Tage. Keine automatische Verlängerung.
+    {% endblocktrans %}
+{% elif not subscription.has_periods %}
+    {% blocktrans trimmed with until=end_of_business_year|date:'d.M' %}
+        Bis {{ until }}. Automatische Verlängerung.
+    {% endblocktrans %}
+{% endif %}

--- a/juntagrico/templates/juntagrico/subscription/create/summary/snippets/part.html
+++ b/juntagrico/templates/juntagrico/subscription/create/summary/snippets/part.html
@@ -1,25 +1,34 @@
+{% load juntagrico.snippets %}
 {% load juntagrico.common %}
 {% load i18n %}
 {% load juntagrico.config %}
 
 <strong>{{ amount }}</strong>&times; {{ type.name }}
-{% if type.has_periods %}
-    {% for period in type.periods.all %}
-        <br/>
-        {{ period.start_day }}.{{ period.start_month }}. - {{ period.end_day }}.{{ period.end_month }}.
-        {{ period.price|price }}
-    {% endfor %}
-{% else %}
-    <strong>
-    {% if type.trial_days %}
-        {%blocktrans trimmed with tp=type.price|price %}
-         à {{ tp }}.
-        {%endblocktrans%}
+{% block price %}
+    {% if type.has_periods %}
+        {% block periodic_price %}
+            {% for period in type.periods.all %}
+                <br/>
+                {{ period.start_day }}.{{ period.start_month }}. - {{ period.end_day }}.{{ period.end_month }}.
+                {{ period.price|price }}
+            {% endfor %}
+        {% endblock %}
     {% else %}
-        {%blocktrans trimmed with tp=type.price|price %}
-         à {{ tp }} pro Jahr.
-        {%endblocktrans%}
+        <strong>
+        {% if type.trial_days %}
+            {% block trial_price %}
+                {%blocktrans trimmed with tp=type.price|price %}
+                    à {{ tp }}.
+                {%endblocktrans%}
+            {% endblock %}
+        {% else %}
+            {% block regular_price %}
+                {%blocktrans trimmed with tp=type.price|price %}
+                    à {{ tp }} pro Jahr.
+                {%endblocktrans%}
+            {% endblock %}
+        {% endif %}
+        </strong>
+        {% type_duration_info type %}
     {% endif %}
-    </strong>
-    {{ type.min_duration_info }}
-{% endif %}
+{% endblock %}

--- a/juntagrico/templatetags/juntagrico/snippets.py
+++ b/juntagrico/templatetags/juntagrico/snippets.py
@@ -11,6 +11,7 @@ from juntagrico.entity.jobs import Job, RecuringJob, JobMessage
 from juntagrico.entity.membership import Membership
 from juntagrico.entity.share import Share
 from juntagrico.forms.job import AddAssignmentForm, AddJobMessageForm
+from juntagrico.util import temporal
 
 register = template.Library()
 
@@ -95,6 +96,14 @@ def subscription_depot_fee(subscription_type, depot=''):
         condition = subscription_type.depot_conditions.filter(depot=depot).first()
         fee = condition.fee if condition else 0
     return fee
+
+
+@register.inclusion_tag('juntagrico/snippets/subscription/type_duration_info.html')
+def type_duration_info(subscription):
+    return {
+        'subscription': subscription,
+        'end_of_business_year': temporal.end_of_business_year(),
+    }
 
 
 @register.inclusion_tag('juntagrico/snippets/action_date.html')


### PR DESCRIPTION
# Description
basic implementation of #892
Enable more granular template overrides for changing how subscription prices are displayed.

users can create their own templatetags to divide for weekly or monthly prices if needed.

# TODO
- [x] write tests

# Release Notes
`SubscriptionType.min_duration_info()` has been removed. override the template `juntagrico/snippets/subscription/type_duration_info.html` instead if necessary.
